### PR TITLE
fix(metrics): correct totalProviders and activeProviders calculation

### DIFF
--- a/apps/backend/src/metrics/dto/network-stats.dto.ts
+++ b/apps/backend/src/metrics/dto/network-stats.dto.ts
@@ -14,7 +14,7 @@ export class NetworkOverallStatsDto {
     description: "Number of FWSS approved storage providers",
     example: 12,
   })
-  activeProviders: number;
+  approvedProviders: number;
 
   @ApiProperty({
     description: "Total number of deals across all providers",

--- a/apps/web/src/components/Home/SummaryCards/index.tsx
+++ b/apps/web/src/components/Home/SummaryCards/index.tsx
@@ -38,7 +38,7 @@ function SummaryCards() {
       {
         label: "TOTAL PROVIDERS",
         value: formatNumber(data.totalProviders),
-        description: `${formatNumber(data.activeProviders)} active`,
+        description: `${formatNumber(data.approvedProviders)} approved`,
       },
       {
         label: "TOTAL UPLOADS",

--- a/apps/web/src/types/network.ts
+++ b/apps/web/src/types/network.ts
@@ -8,7 +8,7 @@
  */
 export interface NetworkOverallStats {
   totalProviders: number;
-  activeProviders: number;
+  approvedProviders: number;
   totalDeals: number;
   successfulDeals: number;
   dealSuccessRate: number;


### PR DESCRIPTION
Closes: #59 

Previously, totalProviders and activeProviders were both counting providers with performance data from sp_performance_all_time, making them identical.

Now:
- totalProviders: Counts all providers from storage_providers table
- activeProviders: Counts only FWSS approved providers (is_approved = true)