### PR TITLE
feat: use filecoin-pin for IPNI validation

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -44,7 +44,7 @@
     "cors": "^2.8.5",
     "cron": "4.3.5",
     "ethers": "^6.16.0",
-    "filecoin-pin": "^0.14.0",
+    "filecoin-pin": "^0.15.0",
     "helmet": "^8.1.0",
     "https-proxy-agent": "^7.0.6",
     "joi": "^17.13.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^6.16.0
         version: 6.16.0
       filecoin-pin:
-        specifier: ^0.14.0
-        version: 0.14.0(iso-filecoin@7.4.7(typescript@5.9.3))(react-native@0.83.1(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(typescript@5.9.3)(viem@2.42.1(typescript@5.9.3)(zod@4.2.0))(zod@4.2.0)
+        specifier: ^0.15.0
+        version: 0.15.0(iso-filecoin@7.4.7(typescript@5.9.3))(react-native@0.83.1(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(typescript@5.9.3)(viem@2.42.1(typescript@5.9.3)(zod@4.2.0))(zod@4.2.0)
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
@@ -1008,8 +1008,8 @@ packages:
   '@helia/routers@4.0.5':
     resolution: {integrity: sha512-oaXOFsrFWMngi6PVIunr34tCxKTQJx2VETOB4Jq2sKGr7S1aHXrtDePMLYAE95KeP2MpOtSd73WwwuTREoW4hQ==}
 
-  '@helia/unixfs@6.0.4':
-    resolution: {integrity: sha512-/6Irfs1z7I2Wl8szLx5dqmUb9dCRYigCsS2EKBd9gKRzHffqcwmYSNNJpzoK/rOg/zMl56dzzhBLcxrdncs96g==}
+  '@helia/unixfs@7.0.1':
+    resolution: {integrity: sha512-KXijBw5OH0unvWiRCTwrQdotmIlXGnntc3DwTwuvPojQApvm/Qj8HiTbR7WXDh8aaBGdD32FtqV40CU5536/VA==}
 
   '@helia/utils@2.3.3':
     resolution: {integrity: sha512-1jen0FvJ6K5HtP4BZiT0NwyaDZ+aGjYuIxpVsb7vV8EmBn//57nyd59ElpXTwM8Npid624RuDRsqtgKVowHDOA==}
@@ -3916,8 +3916,8 @@ packages:
     resolution: {integrity: sha512-boU4EHmP3JXkwDo4uhyBhTt5pPstxB6eEXKJBu2yu2l7aAMMm7QQYQEzssJmKReZYrFdFOJS8koVo6bXIBGDqA==}
     engines: {node: '>=20'}
 
-  filecoin-pin@0.14.0:
-    resolution: {integrity: sha512-1hvyNgKf8z3NqaXokpRLS0s7D6F23xwhj9pEHQZTCTQB9FQnI692CctVtQIKLtD8uIZ9goylUzdhi5rtskn/dw==}
+  filecoin-pin@0.15.0:
+    resolution: {integrity: sha512-P0i5X1FnpRjQrAjlUhZ9qX+EzElPJ/Gl5I7hRaDFwexunDvx954eFpwDcukw/h2qmG6nztjQPbi9d6F+un08mg==}
     hasBin: true
 
   fill-range@7.1.1:
@@ -4214,8 +4214,8 @@ packages:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
     engines: {node: '>= 10'}
 
-  ipfs-unixfs-exporter@14.0.2:
-    resolution: {integrity: sha512-f8XeDrpPS2YNsSHI3aT9IcsVBHcaExLAuEafZTXCWqMk/vJnwAkna6trGPlUXjf+8gaYwCoIaS0gUGlTz45UUQ==}
+  ipfs-unixfs-exporter@15.0.2:
+    resolution: {integrity: sha512-N5dSNH5Rx2VVWuAkBc3xlYR/bqegXyDgKfcGGi8e//VK/FhYcUccvPrvIRBRCEEdP6cbTA+LigkRYBeUrxK11g==}
 
   ipfs-unixfs-importer@16.0.2:
     resolution: {integrity: sha512-3fmHPCAoblhIsDAsR07DjqrS00MvnpZg95fK+9TLFESiYLIsABOnJ7YRPfUyKpCx9un1KWm4z7/zhSoLz7dssA==}
@@ -6687,22 +6687,22 @@ snapshots:
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.28.5)':
     dependencies:
@@ -6712,52 +6712,52 @@ snapshots:
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -7250,7 +7250,7 @@ snapshots:
       multiformats: 13.4.2
       uint8arrays: 5.1.0
 
-  '@helia/unixfs@6.0.4':
+  '@helia/unixfs@7.0.1':
     dependencies:
       '@helia/interface': 6.0.2
       '@ipld/dag-pb': 4.1.5
@@ -7261,7 +7261,7 @@ snapshots:
       hamt-sharding: 3.0.6
       interface-blockstore: 6.0.1
       ipfs-unixfs: 12.0.0
-      ipfs-unixfs-exporter: 14.0.2
+      ipfs-unixfs-exporter: 15.0.2
       ipfs-unixfs-importer: 16.0.2
       it-all: 3.0.9
       it-first: 3.0.9
@@ -10011,7 +10011,7 @@ snapshots:
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.2.1
@@ -10822,12 +10822,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  filecoin-pin@0.14.0(iso-filecoin@7.4.7(typescript@5.9.3))(react-native@0.83.1(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(typescript@5.9.3)(viem@2.42.1(typescript@5.9.3)(zod@4.2.0))(zod@4.2.0):
+  filecoin-pin@0.15.0(iso-filecoin@7.4.7(typescript@5.9.3))(react-native@0.83.1(@babel/core@7.28.5)(@types/react@19.2.7)(react@19.2.1))(typescript@5.9.3)(viem@2.42.1(typescript@5.9.3)(zod@4.2.0))(zod@4.2.0):
     dependencies:
       '@clack/prompts': 0.11.0
       '@filoz/synapse-core': 0.1.4(iso-filecoin@7.4.7(typescript@5.9.3))(typescript@5.9.3)(viem@2.42.1(typescript@5.9.3)(zod@4.2.0))(zod@4.2.0)
       '@filoz/synapse-sdk': 0.36.1(iso-filecoin@7.4.7(typescript@5.9.3))(typescript@5.9.3)(zod@4.2.0)
-      '@helia/unixfs': 6.0.4
+      '@helia/unixfs': 7.0.1
       '@ipld/car': 5.4.2
       commander: 14.0.2
       ethers: 6.16.0
@@ -11200,7 +11200,7 @@ snapshots:
 
   ipaddr.js@2.3.0: {}
 
-  ipfs-unixfs-exporter@14.0.2:
+  ipfs-unixfs-exporter@15.0.2:
     dependencies:
       '@ipld/dag-cbor': 9.2.5
       '@ipld/dag-json': 10.2.5
@@ -11209,7 +11209,6 @@ snapshots:
       hamt-sharding: 3.0.6
       interface-blockstore: 6.0.1
       ipfs-unixfs: 12.0.0
-      it-filter: 3.1.4
       it-last: 3.0.9
       it-map: 3.1.4
       it-parallel: 3.0.13


### PR DESCRIPTION
## Summary
Swapped Dealbot’s custom IPNI verification with filecoin-pin’s waitForIpniProviderResults, removing ~240 LOC of bespoke HTTP/validation logic and aligning behavior with the filecoin-pin CLI/GitHub Action.

## What changed
- Added dependency: filecoin-pin (^0.14.0)
- `monitorAndVerifyIPNI()` now delegates to `waitForIpniProviderResults`
- Added `buildExpectedProviderInfo()` to map Dealbot StorageProvider → Synapse ProviderInfo
- Safer null handling for `deal.storageProvider` in `startIpniMonitoring()`
- Deleted old IPNI verification/query helpers (and unused imports)

## Behavior note
Verification is now root CID only (no per-block CID checks), matching filecoin-pin’s current behavior. Counts now reflect that (total = 1, verified = 0/1). Curio, as far as I can tell, does not announce individual block CIDs inside a rootCID.

follow-up for child block checks should be handled by filecoin-pin. tracking issue at https://github.com/filecoin-project/filecoin-pin/issues/303

## Why
- One shared source of truth for IPNI verification
- Less code to maintain in Dealbot
- More consistent results across tooling

## Related

- #69
