### PR TITLE
fix(web): display 'Unknown' for curio version when SP version check fails

### DIFF
--- a/apps/web/src/components/Home/StorageProviders/ProviderCard/ProviderCardHeader.tsx
+++ b/apps/web/src/components/Home/StorageProviders/ProviderCard/ProviderCardHeader.tsx
@@ -8,7 +8,6 @@ interface ProviderCardHeaderProps {
   provider: Provider;
   version?: string;
   versionLoading: boolean;
-  versionError: string | null;
   hasMetrics: boolean;
   health: {
     status: string;
@@ -25,7 +24,6 @@ function ProviderCardHeader({
   provider,
   version,
   versionLoading,
-  versionError,
   hasMetrics,
   health,
   isImproving,
@@ -77,17 +75,12 @@ function ProviderCardHeader({
 
       {versionLoading ? (
         <Skeleton className="h-5 w-full" />
-      ) : versionError ? (
+      ) : (
         <div className="text-sm flex justify-between items-center gap-2 mb-0">
           <p className="text-sm text-muted-foreground">Curio Version:</p>
-          <span className="font-medium text-muted-foreground">Unknown</span>
+          <span className="font-medium">{version ?? "Unknown"}</span>
         </div>
-      ) : version ? (
-        <div className="text-sm flex justify-between items-center gap-2 mb-0">
-          <p className="text-sm text-muted-foreground">Curio Version:</p>
-          <span className="font-medium">{version}</span>
-        </div>
-      ) : null}
+      )}
 
       {hasMetrics && (
         <div className="flex items-center justify-between mt-3 pt-3 border-t">

--- a/apps/web/src/components/Home/StorageProviders/ProviderCard/index.tsx
+++ b/apps/web/src/components/Home/StorageProviders/ProviderCard/index.tsx
@@ -17,7 +17,7 @@ interface ProviderCardProps {
 function ProviderCard({ provider, batchedVersion }: ProviderCardProps) {
   const [copiedProvider, setCopiedProvider] = useState<string | null>(null);
   const [showDetailModal, setShowDetailModal] = useState(false);
-  const { version, loading, error } = useProviderVersion({
+  const { version, loading } = useProviderVersion({
     serviceUrl: provider.provider.serviceUrl,
     batchedVersion,
   });
@@ -92,7 +92,6 @@ function ProviderCard({ provider, batchedVersion }: ProviderCardProps) {
           provider={provider.provider}
           version={version}
           versionLoading={loading}
-          versionError={error}
           hasMetrics={hasMetrics}
           health={health}
           isImproving={isImproving}


### PR DESCRIPTION
 ## Summary                                                        
- Display "Curio Version: Unknown" when SP version check fails instead of hiding the version section entirely                     
- Uses muted styling to indicate the version could not be retrieved                                                          

Closes #99                                                         
                                                     