### PR TITLE
fix(web): show "UNKNOWN" curio version if check fails

### DIFF
--- a/apps/web/src/components/Home/StorageProviders/ProviderCard/ProviderCardHeader.tsx
+++ b/apps/web/src/components/Home/StorageProviders/ProviderCard/ProviderCardHeader.tsx
@@ -78,7 +78,7 @@ function ProviderCardHeader({
       ) : (
         <div className="text-sm flex justify-between items-center gap-2 mb-0">
           <p className="text-sm text-muted-foreground">Curio Version:</p>
-          <span className="font-medium">{version ?? "Unknown"}</span>
+          <span className="font-medium">{version || "Unknown"}</span>
         </div>
       )}
 


### PR DESCRIPTION
The default value for `version` is an empty string, so the nullish coalescing operator (`??`) always resolves to `""`. Switched to the logical OR (`||`) operator instead.

closes #99 