### PR TITLE
fix: ENV var defaults

### DIFF
--- a/apps/backend/src/config/app.config.ts
+++ b/apps/backend/src/config/app.config.ts
@@ -20,8 +20,6 @@ export const configValidationSchema = Joi.object({
   WALLET_ADDRESS: Joi.string().required(),
   WALLET_PRIVATE_KEY: Joi.string().required(),
   CHECK_DATASET_CREATION_FEES: Joi.boolean().default(true),
-  OVERRIDE_CONTRACT_ADDRESSES: Joi.boolean().default(false),
-  WARM_STORAGE_SERVICE_ADDRESS: Joi.string().optional(),
   USE_ONLY_APPROVED_PROVIDERS: Joi.boolean().default(true),
   ENABLE_CDN_TESTING: Joi.boolean().default(true),
   ENABLE_IPNI_TESTING: Joi.boolean().default(true),
@@ -110,8 +108,6 @@ export interface IBlockchainConfig {
   walletAddress: string;
   walletPrivateKey: string;
   checkDatasetCreationFees: boolean;
-  overrideContractAddresses: boolean;
-  warmStorageServiceAddress: string;
   useOnlyApprovedProviders: boolean;
   enableCDNTesting: boolean;
   enableIpniTesting: boolean;
@@ -178,8 +174,6 @@ export function loadConfig(): IConfig {
       walletAddress: process.env.WALLET_ADDRESS || "0x0000000000000000000000000000000000000000",
       walletPrivateKey: process.env.WALLET_PRIVATE_KEY || "",
       checkDatasetCreationFees: process.env.CHECK_DATASET_CREATION_FEES !== "false",
-      overrideContractAddresses: process.env.OVERRIDE_CONTRACT_ADDRESSES === "true",
-      warmStorageServiceAddress: process.env.WARM_STORAGE_SERVICE_ADDRESS || "",
       useOnlyApprovedProviders: process.env.USE_ONLY_APPROVED_PROVIDERS !== "false",
       enableCDNTesting: process.env.ENABLE_CDN_TESTING !== "false",
       enableIpniTesting: process.env.ENABLE_IPNI_TESTING !== "false",

--- a/apps/backend/src/wallet-sdk/wallet-sdk.service.ts
+++ b/apps/backend/src/wallet-sdk/wallet-sdk.service.ts
@@ -344,9 +344,7 @@ export class WalletSdkService implements OnModuleInit {
   }
 
   getFWSSAddress(): string {
-    return this.blockchainConfig.overrideContractAddresses && this.blockchainConfig.warmStorageServiceAddress
-      ? this.blockchainConfig.warmStorageServiceAddress
-      : CONTRACT_ADDRESSES.WARM_STORAGE[this.blockchainConfig.network];
+    return CONTRACT_ADDRESSES.WARM_STORAGE[this.blockchainConfig.network];
   }
 
   /**


### PR DESCRIPTION
I noticed some discrepancies between the joi schema, env var documentation, and the actual app.config.ts `loadConfig` function.

This PR ensure the values from `loadConfig` are consistent with the joi schema and env var documentation.
