### PR TITLE
fix: use node:25-alpine for docker images

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:25-alpine AS builder
 
 WORKDIR /app
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:25-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
This fixes an issue seen in staging: https://telemetry.betterstack.com/team/t468215/tail\?s\=1678393\&sv\=2855451\&q\=IPNI\&a\=1769082032249821.72116555\&rf\=1766496259144000\&rt\=1769088259144000

```
[Nest] 13 - 01/22/2026, 11:40:32 AM WARN [IpniAddonStrategy] IPNI verification failed: lastActualMultiaddrs.intersection is not a function
```