### PR TITLE
fix: better error messages and ipni data size check fix

### DIFF
--- a/apps/backend/src/common/errors.ts
+++ b/apps/backend/src/common/errors.ts
@@ -1,0 +1,34 @@
+/**
+ * Response information extracted from HTTP errors
+ */
+export interface RetrievalErrorResponseInfo {
+  statusCode?: number;
+  responsePreview?: string;
+}
+
+/**
+ * Custom error class for retrieval failures with HTTP context
+ * Provides structured information about failed HTTP requests
+ */
+export class RetrievalError extends Error {
+  readonly name = "RetrievalError";
+
+  constructor(
+    message: string,
+    public readonly responseInfo?: RetrievalErrorResponseInfo,
+    public readonly code?: string,
+  ) {
+    super(message);
+    // Maintains proper stack trace for where error was thrown (only in V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, RetrievalError);
+    }
+  }
+
+  /**
+   * Create a RetrievalError from an HTTP response
+   */
+  static fromHttpResponse(statusCode: number, responsePreview?: string): RetrievalError {
+    return new RetrievalError(`HTTP ${statusCode} response`, { statusCode, responsePreview });
+  }
+}


### PR DESCRIPTION
1. more informative errors for retrieval failures.
2. fixes an issue where we were not checking retrieved data size against the uploaded car file size.
3. when retrieving content, validate we get a 2xx status code, log an error if we don't.

PDP servers <pdp-server-endpoint>/ipfs/<cid> return the CAR file as the response body, not the original data.

Also should help us look into errors like https://telemetry.betterstack.com/team/t468215/tail?s=1678393&sv=2855451&q=ERROR%20OR%20WARN&a=1769108402268878.117016015&rf=1766526286382000&rt=1769118286382000 further.. a size of 64 seems to indicate a non-2xx status code (which also wasn't being checked) and an error message.
