### PR TITLE
fix: pass valid accept/format parameter for ipfs query

### DIFF
--- a/apps/backend/src/retrieval-addons/strategies/ipni.strategy.ts
+++ b/apps/backend/src/retrieval-addons/strategies/ipni.strategy.ts
@@ -64,12 +64,16 @@ export class IpniRetrievalStrategy implements IRetrievalAddon {
 
     const serviceUrl = providerInfo.products.PDP.data.serviceURL;
     const url = `${serviceUrl.replace(/\/$/, "")}/ipfs/${rootCID}`;
+    const headers = {
+      Accept: "application/vnd.ipld.car",
+    };
 
     this.logger.debug(`Constructed IPNI retrieval URL: ${url}`);
 
     return {
       url,
       method: this.name,
+      headers,
       httpVersion: "2",
     };
   }


### PR DESCRIPTION
Fixes the error when retreiving IPFS CAR from IPNI provider:

```
[Nest] 13 - 01/23/2026, 4:00:02 PM ERROR [RetrievalAddonsService] Retrieval failed for ipfs_pin: HTTP 400 response (deal=f72c77e1-664e-409e-ad42-604626e1ff18 piece=bafkzcibf6x7... sp=0x6ABcF87adC44e27582a3e2bB5EDe97bcFe40043F url=https://pdp.oplian.com/ipfs/bafkreic4iybfd5pphwnui26jd7bzstzok7ykahbuy5tzzcalonh4jjvfti http=2 headers=none auth=no status=400 response="neither a valid Accept header nor format parameter were provided")
```
