### PR TITLE
fix: allow always enabling IPNI testing

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -103,8 +103,7 @@ All configuration is done via environment variables in `.env`.
 | `WALLET_PRIVATE_KEY`          | Your wallet private key (keep secure!) | `0x...`                    |
 | `CHECK_DATASET_CREATION_FEES` | Check fees before dataset creation     | `true`                     |
 | `ENABLE_CDN_TESTING`          | Enable CDN retrieval testing           | `true`                     |
-| `ENABLE_IPNI_TESTING`         | Enable IPNI retrieval testing          | `true`                     |
-| `ALWAYS_ENABLE_IPNI`          | Always enable IPNI (no randomization)  | `true`                     |
+| `ENABLE_IPNI_TESTING`         | IPNI testing mode (`disabled`/`random`/`always`) | `always`          |
 | `USE_ONLY_APPROVED_PROVIDERS` | Only use approved storage providers    | `true`                     |
 
 ### Scheduling Configuration

--- a/apps/backend/src/config/app.config.ts
+++ b/apps/backend/src/config/app.config.ts
@@ -22,8 +22,10 @@ export const configValidationSchema = Joi.object({
   CHECK_DATASET_CREATION_FEES: Joi.boolean().default(true),
   USE_ONLY_APPROVED_PROVIDERS: Joi.boolean().default(true),
   ENABLE_CDN_TESTING: Joi.boolean().default(true),
-  ENABLE_IPNI_TESTING: Joi.boolean().default(true),
-  ALWAYS_ENABLE_IPNI: Joi.boolean().default(true),
+  ENABLE_IPNI_TESTING: Joi.string()
+    .lowercase()
+    .valid("disabled", "random", "always", "true", "false")
+    .default("always"),
   DEALBOT_DATASET_VERSION: Joi.string().optional(),
 
   // Scheduling
@@ -90,6 +92,8 @@ export const configValidationSchema = Joi.object({
     }), // Stop retrieval batch 60s before next run
 });
 
+export type IpniTestingMode = "disabled" | "random" | "always";
+
 export interface IAppConfig {
   env: string;
   port: number;
@@ -111,8 +115,7 @@ export interface IBlockchainConfig {
   checkDatasetCreationFees: boolean;
   useOnlyApprovedProviders: boolean;
   enableCDNTesting: boolean;
-  enableIpniTesting: boolean;
-  alwaysEnableIpni: boolean;
+  enableIpniTesting: IpniTestingMode;
   dealbotDataSetVersion?: string;
 }
 
@@ -157,6 +160,23 @@ export interface IConfig {
   timeouts: ITimeoutConfig;
 }
 
+const parseIpniTestingMode = (value: string | undefined): IpniTestingMode => {
+  if (!value) {
+    return "always";
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "true") {
+    return "always";
+  }
+  if (normalized === "false") {
+    return "disabled";
+  }
+  if (normalized === "disabled" || normalized === "random" || normalized === "always") {
+    return normalized;
+  }
+  return "always";
+};
+
 export function loadConfig(): IConfig {
   return {
     app: {
@@ -178,8 +198,7 @@ export function loadConfig(): IConfig {
       checkDatasetCreationFees: process.env.CHECK_DATASET_CREATION_FEES !== "false",
       useOnlyApprovedProviders: process.env.USE_ONLY_APPROVED_PROVIDERS !== "false",
       enableCDNTesting: process.env.ENABLE_CDN_TESTING !== "false",
-      enableIpniTesting: process.env.ENABLE_IPNI_TESTING !== "false",
-      alwaysEnableIpni: process.env.ALWAYS_ENABLE_IPNI !== "false",
+      enableIpniTesting: parseIpniTestingMode(process.env.ENABLE_IPNI_TESTING),
       dealbotDataSetVersion: process.env.DEALBOT_DATASET_VERSION,
     },
     scheduling: {

--- a/apps/backend/src/deal/deal.service.spec.ts
+++ b/apps/backend/src/deal/deal.service.spec.ts
@@ -55,7 +55,7 @@ describe("DealService", () => {
       network: "calibration",
       walletAddress: "0x123",
       enableCDNTesting: true,
-      enableIpniTesting: true,
+      enableIpniTesting: "always",
     }),
   };
 
@@ -228,7 +228,7 @@ describe("DealService", () => {
           network: "calibration",
           walletAddress: "0x123",
           enableCDNTesting: true,
-          enableIpniTesting: true,
+          enableIpniTesting: "always",
           dealbotDataSetVersion,
         });
 

--- a/apps/backend/src/deal/deal.service.ts
+++ b/apps/backend/src/deal/deal.service.ts
@@ -49,8 +49,17 @@ export class DealService implements OnModuleInit {
   async createDealsForAllProviders(): Promise<Deal[]> {
     const totalProviders = this.walletSdkService.getTestingProvidersCount();
     const enableCDN = this.blockchainConfig.enableCDNTesting ? Math.random() > 0.5 : false;
-    const enableIpni =
-      this.blockchainConfig.enableIpniTesting && (this.blockchainConfig.alwaysEnableIpni || Math.random() > 0.5);
+    const enableIpni = (() => {
+      switch (this.blockchainConfig.enableIpniTesting) {
+        case "disabled":
+          return false;
+        case "random":
+          return Math.random() > 0.5;
+        // case "always": // left commented out because it's the default case and biome doesn't like fallthroughs
+        default:
+          return true;
+      }
+    })();
 
     this.logger.log(`Starting deal creation for ${totalProviders} providers (CDN: ${enableCDN}, IPNI: ${enableIpni})`);
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -8,7 +8,7 @@ This document provides a comprehensive guide to all environment variables used b
 | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [Application](#application-configuration) | `NODE_ENV`, `DEALBOT_PORT`, `DEALBOT_HOST`, `DEALBOT_ALLOWED_ORIGINS`                                                                                        |
 | [Database](#database-configuration)       | `DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_USER`, `DATABASE_PASSWORD`, `DATABASE_NAME`                                                                      |
-| [Blockchain](#blockchain-configuration)   | `NETWORK`, `WALLET_ADDRESS`, `WALLET_PRIVATE_KEY`, `CHECK_DATASET_CREATION_FEES`, `USE_ONLY_APPROVED_PROVIDERS`, `ENABLE_CDN_TESTING`, `ENABLE_IPNI_TESTING`, `ALWAYS_ENABLE_IPNI` |
+| [Blockchain](#blockchain-configuration)   | `NETWORK`, `WALLET_ADDRESS`, `WALLET_PRIVATE_KEY`, `CHECK_DATASET_CREATION_FEES`, `USE_ONLY_APPROVED_PROVIDERS`, `ENABLE_CDN_TESTING`, `ENABLE_IPNI_TESTING` |
 | [Dataset Versioning](#dataset-versioning) | `DEALBOT_DATASET_VERSION`                                                                                                                                    |
 | [Scheduling](#scheduling-configuration)   | `DEAL_INTERVAL_SECONDS`, `RETRIEVAL_INTERVAL_SECONDS`, `DEAL_START_OFFSET_SECONDS`, `RETRIEVAL_START_OFFSET_SECONDS`, `METRICS_START_OFFSET_SECONDS`         |
 | [Dataset](#dataset-configuration)         | `DEALBOT_LOCAL_DATASETS_PATH`, `KAGGLE_DATASET_TOTAL_PAGES`, `RANDOM_DATASET_SIZES`                                                                          |
@@ -304,33 +304,20 @@ WALLET_ADDRESS=0x1234567890abcdef1234567890abcdef12345678
 
 ### `ENABLE_IPNI_TESTING`
 
-- **Type**: `boolean`
+- **Type**: `string` (enum)
 - **Required**: No
-- **Default**: `true`
+- **Default**: `always`
+- **Valid values**: `disabled`, `random`, `always`
 
-**Role**: Enables deal-making with IPFS support. Adds a key(`withIPFSIndexing`) to dataset metadata, used to request that IPFS indexing is performed.
+**Role**: Controls if IPNI is enabled for deals. Adds a key (`withIPFSIndexing`) to dataset metadata when IPNI is enabled.
 
 **When to update**:
 
-- Set to `false` to skip deal-making with IPFS support.
-- Keep as `true` for deal-making with IPNI Indexing support.
+- Set to `disabled` to skip deal-making with IPNI support.
+- Set to `random` to enable IPNI for ~50% of deals.
+- Set to `always` to enable IPNI for every deal.
 
----
-
-### `ALWAYS_ENABLE_IPNI`
-
-- **Type**: `boolean`
-- **Required**: No
-- **Default**: `true`
-
-**Role**: When `ENABLE_IPNI_TESTING` is `true`, forces IPNI on for every deal (no randomization). Randomized IPNI only happens when `ENABLE_IPNI_TESTING=true` and `ALWAYS_ENABLE_IPNI=false`.
-
-**When to update**:
-
-- Set to `false` to keep IPNI as a randomized test path.
-- Keep as `true` to always enable IPNI when testing is enabled.
-
-**Note**: If `ENABLE_IPNI_TESTING=false`, IPNI is disabled regardless of this setting.
+**Note**: Legacy values `true` and `false` are accepted and map to `always` and `disabled` respectively.
 
 ---
 


### PR DESCRIPTION
Based on discussions with @biglep. We should always be testing IPNI functionality with SPs.

You can keep the prior behavior by setting `ALWAYS_ENABLE_IPNI=false` and `ENABLE_IPNI_TESTING=true`.
