### PR TITLE
fix: do not wait so long for piece and ipni status

### DIFF
--- a/apps/backend/src/deal-addons/strategies/ipni.strategy.ts
+++ b/apps/backend/src/deal-addons/strategies/ipni.strategy.ts
@@ -75,9 +75,8 @@ export class IpniAddonStrategy implements IDealAddon<IpniMetadata> {
   readonly name = ServiceType.IPFS_PIN;
   readonly priority = AddonPriority.HIGH; // Run first to transform data
   readonly POLLING_INTERVAL_MS = 2500;
-  readonly POLLING_TIMEOUT_MS = 10 * 60 * 1000;
-  readonly IPNI_LOOKUP_TIMEOUT_MS = 60 * 60 * 1000;
-  readonly IPNI_VERIFICATION_RETRY_INTERVAL_MS = 10 * 1000;
+  readonly POLLING_TIMEOUT_MS = 2 * 60 * 1000; // 2 minutes - max time to wait for SP to advertise piece
+  readonly IPNI_LOOKUP_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes - max time to wait for IPNI propagation
 
   /**
    * Check if IPNI is enabled in the deal configuration


### PR DESCRIPTION
we used to wait 10 min for sp to index + advertise the piece.. now we will wait only 2 minutes.

we used to wait up to 60 minutes for IPNI to list the SP as a provider, now we will wait only 3 minutes.