### PR TITLE
fix: increase concurrency for deals & retrievals

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -113,9 +113,9 @@ Control when and how often automated jobs run:
 | Variable                         | Description                       | Recommended |
 | -------------------------------- | --------------------------------- | ----------------- |
 | `DEAL_INTERVAL_SECONDS`          | How often to create new deals     | `1800` (30 min)   |
-| `DEAL_MAX_CONCURRENCY`           | Max parallel deal creations       | `6`               |
+| `DEAL_MAX_CONCURRENCY`           | Max parallel deal creations       | `10`              |
 | `RETRIEVAL_INTERVAL_SECONDS`     | How often to test retrievals      | `3600` (60 min)   |
-| `RETRIEVAL_MAX_CONCURRENCY`      | Max parallel retrieval tests      | `5`               |
+| `RETRIEVAL_MAX_CONCURRENCY`      | Max parallel retrieval tests      | `10`              |
 | `DEAL_START_OFFSET_SECONDS`      | Delay before first deal creation  | `0`               |
 | `RETRIEVAL_START_OFFSET_SECONDS` | Delay before first retrieval test | `300` (5 min)     |
 | `METRICS_START_OFFSET_SECONDS`   | Delay before first metrics job    | `600` (10 min)    |

--- a/apps/backend/src/config/app.config.ts
+++ b/apps/backend/src/config/app.config.ts
@@ -33,8 +33,8 @@ export const configValidationSchema = Joi.object({
 
   // Scheduling
   DEAL_INTERVAL_SECONDS: Joi.number().default(30),
-  DEAL_MAX_CONCURRENCY: Joi.number().integer().min(1).default(6),
-  RETRIEVAL_MAX_CONCURRENCY: Joi.number().integer().min(1).default(5),
+  DEAL_MAX_CONCURRENCY: Joi.number().integer().min(1).default(10),
+  RETRIEVAL_MAX_CONCURRENCY: Joi.number().integer().min(1).default(10),
   RETRIEVAL_INTERVAL_SECONDS: Joi.number()
     .min(1)
     .default(60)
@@ -311,8 +311,8 @@ export function loadConfig(): IConfig {
     },
     scheduling: {
       dealIntervalSeconds: Number.parseInt(process.env.DEAL_INTERVAL_SECONDS || "30", 10),
-      dealMaxConcurrency: Number.parseInt(process.env.DEAL_MAX_CONCURRENCY || "6", 10),
-      retrievalMaxConcurrency: Number.parseInt(process.env.RETRIEVAL_MAX_CONCURRENCY || "5", 10),
+      dealMaxConcurrency: Number.parseInt(process.env.DEAL_MAX_CONCURRENCY || "10", 10),
+      retrievalMaxConcurrency: Number.parseInt(process.env.RETRIEVAL_MAX_CONCURRENCY || "10", 10),
       retrievalIntervalSeconds: Number.parseInt(process.env.RETRIEVAL_INTERVAL_SECONDS || "60", 10),
       dealStartOffsetSeconds: Number.parseInt(process.env.DEAL_START_OFFSET_SECONDS || "0", 10),
       retrievalStartOffsetSeconds: Number.parseInt(process.env.RETRIEVAL_START_OFFSET_SECONDS || "600", 10),

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -400,7 +400,7 @@ DEAL_INTERVAL_SECONDS=3600
 
 - **Type**: `number`
 - **Required**: No
-- **Default**: `6`
+- **Default**: `10`
 - **Minimum**: `1`
 
 **Role**: Controls deal-job concurrency. When `DEALBOT_JOBS_MODE=cron`, this is the maximum number of providers processed in parallel per batch; batches run sequentially. When `DEALBOT_JOBS_MODE=pgboss`, this sets the pg-boss `teamSize` for `deal.run` workers.
@@ -413,7 +413,7 @@ DEAL_INTERVAL_SECONDS=3600
 **Example**:
 
 ```bash
-DEAL_MAX_CONCURRENCY=4
+DEAL_MAX_CONCURRENCY=10
 ```
 
 **Sizing note**: A rough estimate for required concurrency is
@@ -426,7 +426,7 @@ Use p95 duration for a more conservative default.
 
 - **Type**: `number`
 - **Required**: No
-- **Default**: `5`
+- **Default**: `10`
 - **Minimum**: `1`
 
 **Role**: Maximum number of retrieval tests executed in parallel when running pg-boss workers.
@@ -439,7 +439,7 @@ Use p95 duration for a more conservative default.
 **Example**:
 
 ```bash
-RETRIEVAL_MAX_CONCURRENCY=5
+RETRIEVAL_MAX_CONCURRENCY=10
 ```
 
 **Sizing note**: A rough estimate for required concurrency is


### PR DESCRIPTION
with the previous concurrency of 6 deal jobs and 5 retrieval jobs, retrievals were fine, deals were backing up though.

Based on the last 3 hours window:

Created: 218 in 3h → ~72.7/hour
Started: 102 in 3h → ~34/hour

So backlog grew at ~38–39 jobs/hour over that period.

This PR increases the default concurrency

<img width="1040" height="233" alt="image" src="https://github.com/user-attachments/assets/8263dab1-4ea9-4683-b043-3cee160f7b65" />
