### PR TITLE
fix: more granular job duration buckets

### DIFF
--- a/apps/backend/src/metrics-prometheus/metrics-prometheus.module.ts
+++ b/apps/backend/src/metrics-prometheus/metrics-prometheus.module.ts
@@ -153,7 +153,7 @@ const metricProviders = [
     name: "job_duration_seconds",
     help: "Job execution duration in seconds",
     labelNames: ["job_type"] as const,
-    buckets: [1, 2, 3, 4, 5, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330, 360, 420, 600],
+    buckets: [0.1, 0.5, 1, 2, 3, 4, 5, 10, 15, 20, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330, 360, 420, 600],
   }),
   // Upload metrics
   makeHistogramProvider({


### PR DESCRIPTION
deal jobs keep showing P99 as 600 because we don't have more granular buckets for job runtimes. This PR fixes that.

<img width="993" height="309" alt="image" src="https://github.com/user-attachments/assets/be9f5100-6fef-42b8-8183-b7dfa4bf2255" />
