### PR TITLE
fix: providers.refresh queue is created on scheduler startup

### DIFF
--- a/apps/backend/src/jobs/jobs.service.ts
+++ b/apps/backend/src/jobs/jobs.service.ts
@@ -189,13 +189,20 @@ export class JobsService implements OnModuleInit, OnApplicationShutdown {
     boss.on("error", this.bossErrorHandler);
     try {
       await boss.start();
-      await boss.createQueue(SP_WORK_QUEUE, { policy: "singleton" });
+      await this.ensureWorkerQueues(boss);
       this.boss = boss;
     } catch (error) {
       boss.off("error", this.bossErrorHandler);
       this.bossErrorHandler = undefined;
       this.logger.error(`Failed to start pg-boss: ${error.message}`, error.stack);
     }
+  }
+
+  private async ensureWorkerQueues(boss: Pick<PgBoss, "createQueue">): Promise<void> {
+    await boss.createQueue(SP_WORK_QUEUE, { policy: "singleton" });
+    await boss.createQueue(METRICS_QUEUE);
+    await boss.createQueue(METRICS_CLEANUP_QUEUE);
+    await boss.createQueue(PROVIDERS_REFRESH_QUEUE);
   }
 
   private registerWorkers(): void {


### PR DESCRIPTION
## Summary
This PR fixes intermittent worker startup errors:

`Queue providers.refresh does not exist (Queue: providers.refresh, Worker: ...)`

## Root Cause
`JobsService` registered a worker for `providers.refresh`, but startup only explicitly created `sp.work`.

In our deployed topology (`DEALBOT_RUN_MODE=worker`, `DEALBOT_PGBOSS_SCHEDULER_ENABLED=false`), workers can start polling before the scheduler ever creates `providers.refresh`, causing repeated pg-boss errors.

## Fix
- Added explicit startup queue creation for all worker-consumed queues:
1. `sp.work` (singleton policy)
2. `metrics.run`
3. `metrics.cleanup`
4. `providers.refresh`
- Refactored queue creation into a dedicated `ensureWorkerQueues(...)` helper invoked from `startBoss()`.

## Tests
- Updated worker registration test to assert `providers.refresh` worker registration.
- Added a new test to verify all required queues are created during startup.
- Verified with:
  - `pnpm -C apps/backend test -- src/jobs/jobs.service.spec.ts`

## Notes
- Keeping queue creation in worker startup is intentional: `createQueue` is idempotent and avoids scheduler/worker startup races.
- No infra/env changes required.
