### PR TITLE
fix: add explicit text type to job_schedule_state columns

### DIFF
--- a/apps/backend/src/database/entities/job-schedule-state.entity.ts
+++ b/apps/backend/src/database/entities/job-schedule-state.entity.ts
@@ -9,10 +9,10 @@ export class JobScheduleState {
   @PrimaryGeneratedColumn("increment", { type: "bigint" })
   id!: string;
 
-  @Column({ name: "job_type" })
+  @Column({ name: "job_type", type: "text" })
   jobType!: JobType;
 
-  @Column({ name: "sp_address", default: "" })
+  @Column({ name: "sp_address", type: "text", default: "" })
   spAddress!: string;
 
   @Column({ name: "interval_seconds" })


### PR DESCRIPTION
Added explicit type `text` for `jobType` and `spAddress` fields in the `JobScheduleState` entity. This ensures TypeORM respects the migration's schema definition and doesn't attempt type conversion.