### PR TITLE
fix: optimize sp-performance-query.helper.ts

### DIFF
--- a/apps/backend/src/database/helpers/sp-performance-query.helper.ts
+++ b/apps/backend/src/database/helpers/sp-performance-query.helper.ts
@@ -6,149 +6,163 @@ import { IpniStatus, ServiceType } from "../types.js";
  * @returns SQL query string
  */
 export function generateSpPerformanceQuery(dateFilter?: string): string {
+  const retrievalDateFilter = dateFilter?.replaceAll("d.created_at", "r.created_at");
+
   return `
-    SELECT 
-      sp.address as sp_address,
-      
-      -- Deal metrics
-      COUNT(DISTINCT d.id) as total_deals,
-      COUNT(DISTINCT d.id) FILTER (WHERE d.status = 'deal_created') as successful_deals,
-      COUNT(DISTINCT d.id) FILTER (WHERE d.status = 'failed') as failed_deals,
-      
-      -- Deal success rate
-      CASE 
-        WHEN COUNT(DISTINCT d.id) > 0 
-        THEN ROUND(
-          (COUNT(DISTINCT d.id) FILTER (WHERE d.status = 'deal_created')::numeric / 
-          COUNT(DISTINCT d.id)::numeric) * 100, 
-          2
-        )
-        ELSE 0 
-      END as deal_success_rate,
-      
-      -- Deal latency metrics
-      ROUND(AVG(d.ingest_latency_ms) FILTER (WHERE d.ingest_latency_ms IS NOT NULL))::int as avg_ingest_latency_ms,
-      ROUND(AVG(d.chain_latency_ms) FILTER (WHERE d.chain_latency_ms IS NOT NULL))::int as avg_chain_latency_ms,
-      ROUND(AVG(d.deal_latency_ms) FILTER (WHERE d.deal_latency_ms IS NOT NULL))::int as avg_deal_latency_ms,
-      
-      -- Deal throughput
-      ROUND(AVG(d.ingest_throughput_bps) FILTER (WHERE d.ingest_throughput_bps IS NOT NULL))::bigint as avg_ingest_throughput_bps,
-      
-      -- Retrieval metrics (DIRECT_SP only)
-      COUNT(DISTINCT r.id) FILTER (WHERE r.service_type = '${ServiceType.DIRECT_SP}') as total_retrievals,
-      COUNT(DISTINCT r.id) FILTER (WHERE r.status = 'success' AND r.service_type = '${
-        ServiceType.DIRECT_SP
-      }') as successful_retrievals,
-      COUNT(DISTINCT r.id) FILTER (WHERE r.status = 'failed' AND r.service_type = '${
-        ServiceType.DIRECT_SP
-      }') as failed_retrievals,
-      
-      -- Retrieval success rate
-      CASE 
-        WHEN COUNT(DISTINCT r.id) FILTER (WHERE r.service_type = '${ServiceType.DIRECT_SP}') > 0 
-        THEN ROUND(
-          (COUNT(DISTINCT r.id) FILTER (WHERE r.status = 'success' AND r.service_type = '${
-            ServiceType.DIRECT_SP
-          }')::numeric / 
-          COUNT(DISTINCT r.id) FILTER (WHERE r.service_type = '${ServiceType.DIRECT_SP}')::numeric) * 100, 
-          2
-        )
-        ELSE 0 
-      END as retrieval_success_rate,
-      
-      -- Retrieval latency
-      ROUND(AVG(r.latency_ms) FILTER (WHERE r.latency_ms IS NOT NULL AND r.service_type = '${
-        ServiceType.DIRECT_SP
-      }'))::int as avg_retrieval_latency_ms,
-      ROUND(AVG(r.ttfb_ms) FILTER (WHERE r.ttfb_ms IS NOT NULL AND r.service_type = '${
-        ServiceType.DIRECT_SP
-      }'))::int as avg_retrieval_ttfb_ms,
-      ROUND(AVG(r.throughput_bps) FILTER (WHERE r.throughput_bps IS NOT NULL AND r.service_type = '${
-        ServiceType.DIRECT_SP
-      }'))::bigint as avg_retrieval_throughput_bps,
-      
-      -- IPFS retrieval metrics
-      COUNT(DISTINCT r_ipfs.id) FILTER (WHERE r_ipfs.service_type = '${ServiceType.IPFS_PIN}') as total_ipfs_retrievals,
-      COUNT(DISTINCT r_ipfs.id) FILTER (WHERE r_ipfs.status = 'success' AND r_ipfs.service_type = '${
-        ServiceType.IPFS_PIN
-      }') as successful_ipfs_retrievals,
-      COUNT(DISTINCT r_ipfs.id) FILTER (WHERE r_ipfs.status = 'failed' AND r_ipfs.service_type = '${
-        ServiceType.IPFS_PIN
-      }') as failed_ipfs_retrievals,
-      
-      -- IPFS retrieval success rate
-      CASE 
-        WHEN COUNT(DISTINCT r_ipfs.id) FILTER (WHERE r_ipfs.service_type = '${ServiceType.IPFS_PIN}') > 0 
-        THEN ROUND(
-          (COUNT(DISTINCT r_ipfs.id) FILTER (WHERE r_ipfs.status = 'success' AND r_ipfs.service_type = '${
-            ServiceType.IPFS_PIN
-          }')::numeric / 
-          COUNT(DISTINCT r_ipfs.id) FILTER (WHERE r_ipfs.service_type = '${ServiceType.IPFS_PIN}')::numeric) * 100, 
-          2
-        )
-        ELSE 0 
-      END as ipfs_retrieval_success_rate,
-      
-      -- IPFS retrieval performance
-      ROUND(AVG(r_ipfs.latency_ms) FILTER (WHERE r_ipfs.latency_ms IS NOT NULL AND r_ipfs.service_type = '${
-        ServiceType.IPFS_PIN
-      }'))::int as avg_ipfs_retrieval_latency_ms,
-      ROUND(AVG(r_ipfs.ttfb_ms) FILTER (WHERE r_ipfs.ttfb_ms IS NOT NULL AND r_ipfs.service_type = '${
-        ServiceType.IPFS_PIN
-      }'))::int as avg_ipfs_retrieval_ttfb_ms,
-      ROUND(AVG(r_ipfs.throughput_bps) FILTER (WHERE r_ipfs.throughput_bps IS NOT NULL AND r_ipfs.service_type = '${
-        ServiceType.IPFS_PIN
-      }'))::bigint as avg_ipfs_retrieval_throughput_bps,
-      
-      -- IPNI tracking metrics - incremental states: PENDING -> SP_INDEXED -> SP_ADVERTISED -> VERIFIED
-      COUNT(DISTINCT d.id) FILTER (WHERE d.ipni_status IS NOT NULL) as total_ipni_deals,
-      COUNT(DISTINCT d.id) FILTER (WHERE d.ipni_status IN ('${IpniStatus.SP_INDEXED}', '${
-        IpniStatus.SP_ADVERTISED
-      }', '${IpniStatus.VERIFIED}')) as ipni_indexed_deals,
-      COUNT(DISTINCT d.id) FILTER (WHERE d.ipni_status IN ('${IpniStatus.SP_ADVERTISED}', '${IpniStatus.VERIFIED}')) as ipni_advertised_deals,
-      COUNT(DISTINCT d.id) FILTER (WHERE d.ipni_status = '${IpniStatus.VERIFIED}') as ipni_verified_deals,
-      COUNT(DISTINCT d.id) FILTER (WHERE d.ipni_status = '${IpniStatus.FAILED}') as ipni_failed_deals,
-      
-      -- IPNI success rate (based on verified status)
-      CASE 
-        WHEN COUNT(DISTINCT d.id) FILTER (WHERE d.ipni_status IS NOT NULL) > 0 
-        THEN ROUND(
-          (COUNT(DISTINCT d.id) FILTER (WHERE d.ipni_status = '${IpniStatus.VERIFIED}')::numeric / 
-          COUNT(DISTINCT d.id) FILTER (WHERE d.ipni_status IS NOT NULL)::numeric) * 100, 
-          2
-        )
-        ELSE 0 
-      END as ipni_success_rate,
-      
-      -- IPNI performance metrics
-      ROUND(AVG(d.ipni_time_to_index_ms) FILTER (WHERE d.ipni_time_to_index_ms IS NOT NULL))::int as avg_ipni_time_to_index_ms,
-      ROUND(AVG(d.ipni_time_to_advertise_ms) FILTER (WHERE d.ipni_time_to_advertise_ms IS NOT NULL))::int as avg_ipni_time_to_advertise_ms,
-      ROUND(AVG(d.ipni_time_to_verify_ms) FILTER (WHERE d.ipni_time_to_verify_ms IS NOT NULL))::int as avg_ipni_time_to_verify_ms,
-      
-      -- Data volumes
-      SUM(d.file_size) FILTER (WHERE d.status = 'deal_created') as total_data_stored_bytes,
-      SUM(r.bytes_retrieved) FILTER (WHERE r.status = 'success' AND r.service_type = '${
-        ServiceType.DIRECT_SP
-      }') as total_data_retrieved_bytes,
-      SUM(r_ipfs.bytes_retrieved) FILTER (WHERE r_ipfs.status = 'success' AND r_ipfs.service_type = '${
-        ServiceType.IPFS_PIN
-      }') as total_ipfs_data_retrieved_bytes,
-      
-      -- Last activity timestamps
-      MAX(d.created_at) as last_deal_at,
-      MAX(r.created_at) FILTER (WHERE r.service_type = '${ServiceType.DIRECT_SP}') as last_retrieval_at,
-      MAX(r_ipfs.created_at) FILTER (WHERE r_ipfs.service_type = '${ServiceType.IPFS_PIN}') as last_ipfs_retrieval_at,
-      NOW() as refreshed_at
-      
+    WITH deals_filtered AS (
+      SELECT
+        d.id,
+        d.sp_address,
+        d.status,
+        d.ingest_latency_ms,
+        d.chain_latency_ms,
+        d.deal_latency_ms,
+        d.ingest_throughput_bps,
+        d.ipni_status,
+        d.ipni_time_to_index_ms,
+        d.ipni_time_to_advertise_ms,
+        d.ipni_time_to_verify_ms,
+        d.file_size,
+        d.created_at
+      FROM deals d
+      ${dateFilter ? `WHERE ${dateFilter}` : ""}
+    ),
+    deal_metrics AS (
+      SELECT
+        d.sp_address,
+        COUNT(*) AS total_deals,
+        COUNT(*) FILTER (WHERE d.status = 'deal_created') AS successful_deals,
+        COUNT(*) FILTER (WHERE d.status = 'failed') AS failed_deals,
+        ROUND(AVG(d.ingest_latency_ms) FILTER (WHERE d.ingest_latency_ms IS NOT NULL))::int AS avg_ingest_latency_ms,
+        ROUND(AVG(d.chain_latency_ms) FILTER (WHERE d.chain_latency_ms IS NOT NULL))::int AS avg_chain_latency_ms,
+        ROUND(AVG(d.deal_latency_ms) FILTER (WHERE d.deal_latency_ms IS NOT NULL))::int AS avg_deal_latency_ms,
+        ROUND(AVG(d.ingest_throughput_bps) FILTER (WHERE d.ingest_throughput_bps IS NOT NULL))::bigint AS avg_ingest_throughput_bps,
+        COUNT(*) FILTER (WHERE d.ipni_status IS NOT NULL) AS total_ipni_deals,
+        COUNT(*) FILTER (WHERE d.ipni_status IN ('${IpniStatus.SP_INDEXED}', '${IpniStatus.SP_ADVERTISED}', '${
+          IpniStatus.VERIFIED
+        }')) AS ipni_indexed_deals,
+        COUNT(*) FILTER (WHERE d.ipni_status IN ('${IpniStatus.SP_ADVERTISED}', '${IpniStatus.VERIFIED}')) AS ipni_advertised_deals,
+        COUNT(*) FILTER (WHERE d.ipni_status = '${IpniStatus.VERIFIED}') AS ipni_verified_deals,
+        COUNT(*) FILTER (WHERE d.ipni_status = '${IpniStatus.FAILED}') AS ipni_failed_deals,
+        ROUND(AVG(d.ipni_time_to_index_ms) FILTER (WHERE d.ipni_time_to_index_ms IS NOT NULL))::int AS avg_ipni_time_to_index_ms,
+        ROUND(AVG(d.ipni_time_to_advertise_ms) FILTER (WHERE d.ipni_time_to_advertise_ms IS NOT NULL))::int AS avg_ipni_time_to_advertise_ms,
+        ROUND(AVG(d.ipni_time_to_verify_ms) FILTER (WHERE d.ipni_time_to_verify_ms IS NOT NULL))::int AS avg_ipni_time_to_verify_ms,
+        SUM(d.file_size) FILTER (WHERE d.status = 'deal_created') AS total_data_stored_bytes,
+        MAX(d.created_at) AS last_deal_at
+      FROM deals_filtered d
+      GROUP BY d.sp_address
+    ),
+    retrievals_filtered AS (
+      SELECT
+        d.sp_address,
+        r.service_type,
+        r.status,
+        r.latency_ms,
+        r.ttfb_ms,
+        r.throughput_bps,
+        r.bytes_retrieved,
+        r.created_at
+      FROM retrievals r
+      JOIN deals_filtered d ON d.id = r.deal_id
+      ${retrievalDateFilter ? `WHERE ${retrievalDateFilter}` : ""}
+    ),
+    retrieval_metrics AS (
+      SELECT
+        r.sp_address,
+        COUNT(*) FILTER (WHERE r.service_type = '${ServiceType.DIRECT_SP}') AS total_retrievals,
+        COUNT(*) FILTER (WHERE r.status = 'success' AND r.service_type = '${ServiceType.DIRECT_SP}') AS successful_retrievals,
+        COUNT(*) FILTER (WHERE r.status = 'failed' AND r.service_type = '${ServiceType.DIRECT_SP}') AS failed_retrievals,
+        ROUND(AVG(r.latency_ms) FILTER (WHERE r.latency_ms IS NOT NULL AND r.service_type = '${
+          ServiceType.DIRECT_SP
+        }'))::int AS avg_retrieval_latency_ms,
+        ROUND(AVG(r.ttfb_ms) FILTER (WHERE r.ttfb_ms IS NOT NULL AND r.service_type = '${
+          ServiceType.DIRECT_SP
+        }'))::int AS avg_retrieval_ttfb_ms,
+        ROUND(AVG(r.throughput_bps) FILTER (WHERE r.throughput_bps IS NOT NULL AND r.service_type = '${
+          ServiceType.DIRECT_SP
+        }'))::bigint AS avg_retrieval_throughput_bps,
+        COUNT(*) FILTER (WHERE r.service_type = '${ServiceType.IPFS_PIN}') AS total_ipfs_retrievals,
+        COUNT(*) FILTER (WHERE r.status = 'success' AND r.service_type = '${ServiceType.IPFS_PIN}') AS successful_ipfs_retrievals,
+        COUNT(*) FILTER (WHERE r.status = 'failed' AND r.service_type = '${ServiceType.IPFS_PIN}') AS failed_ipfs_retrievals,
+        ROUND(AVG(r.latency_ms) FILTER (WHERE r.latency_ms IS NOT NULL AND r.service_type = '${
+          ServiceType.IPFS_PIN
+        }'))::int AS avg_ipfs_retrieval_latency_ms,
+        ROUND(AVG(r.ttfb_ms) FILTER (WHERE r.ttfb_ms IS NOT NULL AND r.service_type = '${
+          ServiceType.IPFS_PIN
+        }'))::int AS avg_ipfs_retrieval_ttfb_ms,
+        ROUND(AVG(r.throughput_bps) FILTER (WHERE r.throughput_bps IS NOT NULL AND r.service_type = '${
+          ServiceType.IPFS_PIN
+        }'))::bigint AS avg_ipfs_retrieval_throughput_bps,
+        SUM(r.bytes_retrieved) FILTER (WHERE r.status = 'success' AND r.service_type = '${
+          ServiceType.DIRECT_SP
+        }') AS total_data_retrieved_bytes,
+        SUM(r.bytes_retrieved) FILTER (WHERE r.status = 'success' AND r.service_type = '${
+          ServiceType.IPFS_PIN
+        }') AS total_ipfs_data_retrieved_bytes,
+        MAX(r.created_at) FILTER (WHERE r.service_type = '${ServiceType.DIRECT_SP}') AS last_retrieval_at,
+        MAX(r.created_at) FILTER (WHERE r.service_type = '${ServiceType.IPFS_PIN}') AS last_ipfs_retrieval_at
+      FROM retrievals_filtered r
+      GROUP BY r.sp_address
+    )
+    SELECT
+      sp.address AS sp_address,
+      COALESCE(dm.total_deals, 0) AS total_deals,
+      COALESCE(dm.successful_deals, 0) AS successful_deals,
+      COALESCE(dm.failed_deals, 0) AS failed_deals,
+      CASE
+        WHEN COALESCE(dm.total_deals, 0) > 0
+        THEN ROUND((COALESCE(dm.successful_deals, 0)::numeric / dm.total_deals::numeric) * 100, 2)
+        ELSE 0
+      END AS deal_success_rate,
+      dm.avg_ingest_latency_ms,
+      dm.avg_chain_latency_ms,
+      dm.avg_deal_latency_ms,
+      dm.avg_ingest_throughput_bps,
+      COALESCE(rm.total_retrievals, 0) AS total_retrievals,
+      COALESCE(rm.successful_retrievals, 0) AS successful_retrievals,
+      COALESCE(rm.failed_retrievals, 0) AS failed_retrievals,
+      CASE
+        WHEN COALESCE(rm.total_retrievals, 0) > 0
+        THEN ROUND((COALESCE(rm.successful_retrievals, 0)::numeric / rm.total_retrievals::numeric) * 100, 2)
+        ELSE 0
+      END AS retrieval_success_rate,
+      rm.avg_retrieval_latency_ms,
+      rm.avg_retrieval_ttfb_ms,
+      rm.avg_retrieval_throughput_bps,
+      COALESCE(rm.total_ipfs_retrievals, 0) AS total_ipfs_retrievals,
+      COALESCE(rm.successful_ipfs_retrievals, 0) AS successful_ipfs_retrievals,
+      COALESCE(rm.failed_ipfs_retrievals, 0) AS failed_ipfs_retrievals,
+      CASE
+        WHEN COALESCE(rm.total_ipfs_retrievals, 0) > 0
+        THEN ROUND((COALESCE(rm.successful_ipfs_retrievals, 0)::numeric / rm.total_ipfs_retrievals::numeric) * 100, 2)
+        ELSE 0
+      END AS ipfs_retrieval_success_rate,
+      rm.avg_ipfs_retrieval_latency_ms,
+      rm.avg_ipfs_retrieval_ttfb_ms,
+      rm.avg_ipfs_retrieval_throughput_bps,
+      COALESCE(dm.total_ipni_deals, 0) AS total_ipni_deals,
+      COALESCE(dm.ipni_indexed_deals, 0) AS ipni_indexed_deals,
+      COALESCE(dm.ipni_advertised_deals, 0) AS ipni_advertised_deals,
+      COALESCE(dm.ipni_verified_deals, 0) AS ipni_verified_deals,
+      COALESCE(dm.ipni_failed_deals, 0) AS ipni_failed_deals,
+      CASE
+        WHEN COALESCE(dm.total_ipni_deals, 0) > 0
+        THEN ROUND((COALESCE(dm.ipni_verified_deals, 0)::numeric / dm.total_ipni_deals::numeric) * 100, 2)
+        ELSE 0
+      END AS ipni_success_rate,
+      dm.avg_ipni_time_to_index_ms,
+      dm.avg_ipni_time_to_advertise_ms,
+      dm.avg_ipni_time_to_verify_ms,
+      dm.total_data_stored_bytes,
+      rm.total_data_retrieved_bytes,
+      rm.total_ipfs_data_retrieved_bytes,
+      dm.last_deal_at,
+      rm.last_retrieval_at,
+      rm.last_ipfs_retrieval_at,
+      NOW() AS refreshed_at
     FROM storage_providers sp
-    LEFT JOIN deals d ON d.sp_address = sp.address ${dateFilter ? `AND ${dateFilter}` : ""}
-    LEFT JOIN retrievals r ON r.deal_id = d.id ${
-      dateFilter ? `AND ${dateFilter.replace("d.created_at", "r.created_at")}` : ""
-    }
-    LEFT JOIN retrievals r_ipfs ON r_ipfs.deal_id = d.id ${
-      dateFilter ? `AND ${dateFilter.replace("d.created_at", "r_ipfs.created_at")}` : ""
-    }
-    GROUP BY sp.address
+    LEFT JOIN deal_metrics dm ON dm.sp_address = sp.address
+    LEFT JOIN retrieval_metrics rm ON rm.sp_address = sp.address
     ORDER BY total_deals DESC NULLS LAST
   `;
 }


### PR DESCRIPTION
## Summary

This PR rewrites the SQL generated by `generateSpPerformanceQuery()` in `apps/backend/src/database/helpers/sp-performance-query.helper.ts` to reduce migration-time cost when rebuilding SP performance materialized views.

This targets startup instability where pending migrations (`1761500000000`, `1761500000001`) repeatedly execute expensive view creation.

## Problem

`pg_stat_statements` shows `CREATE MATERIALIZED VIEW sp_performance_all_time AS ...` as a major hotspot (roughly ~100s per call, high temp block writes), which contributes to restart loops during migration retries.

## What Changed

- Replaced the previous `COUNT(DISTINCT ...)` + multi-join query shape with staged aggregation:
  - `deals_filtered` -> `deal_metrics`
  - `retrievals_filtered` -> `retrieval_metrics`
  - final join on `storage_providers`
- Preserved existing output columns and semantics used by entities/migrations.
- Kept the same helper entrypoint (`generateSpPerformanceQuery`), so migration call sites remain unchanged.

## Expected Impact

- Faster materialized view creation during migrations.
- Lower temp I/O during migration execution.
- Reduced startup crash-loop risk caused by long-running migration SQL.

## Risk

- No schema changes.
- Query logic changed in a critical metrics path; staging verification is required.

## Validation

- `pnpm typecheck && pnpm lint && pnpm check && pnpm format && pnpm build && pnpm test`
- `pnpm -C apps/backend test -- migrations.e2e-spec.ts`

## Post-Deploy Verification

1. Confirm migrations `1761500000000` and `1761500000001` are applied.
2. Re-check `pg_stat_statements` for reduced runtime/temp I/O on `CREATE MATERIALIZED VIEW sp_performance_all_time AS ...`.
3. Confirm backend startup is stable (no repeated migration attempts).
