### PR TITLE
fix: add fake timers to data_set_creation tests

### DIFF
--- a/apps/backend/src/jobs/jobs.service.spec.ts
+++ b/apps/backend/src/jobs/jobs.service.spec.ts
@@ -965,6 +965,9 @@ describe("JobsService schedule rows", () => {
   });
 
   it("data_set_creation job creates initial data set when minNumDataSetsForChecks is 1", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T12:00:00Z"));
+
     const dealService = {
       getTestingDealOptions: vi.fn(() => ({ enableIpni: true })),
       getBaseDataSetMetadata: vi.fn(() => ({ withIpniIndexing: "" })),
@@ -986,6 +989,9 @@ describe("JobsService schedule rows", () => {
   });
 
   it("data_set_creation job skips when all data sets already exist", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T12:00:00Z"));
+
     baseConfigValues = {
       ...baseConfigValues,
       blockchain: { ...baseConfigValues.blockchain, minNumDataSetsForChecks: 3 } as IConfig["blockchain"],


### PR DESCRIPTION
Two `data_set_creation` tests relied on real system time, causing  failures when run during configured maintenance windows. Adds vi.useFakeTimers() + vi.setSystemTime() to pin them to a safe time.

Reviewer @SgtPooki 