### PR TITLE
fix: log when ipniVerifyMs is > 5s

### DIFF
--- a/apps/backend/src/deal-addons/strategies/ipni.strategy.ts
+++ b/apps/backend/src/deal-addons/strategies/ipni.strategy.ts
@@ -735,11 +735,6 @@ export class IpniAddonStrategy implements IDealAddon<IpniMetadata> {
           message: "IPNI verification time exceeded 5s threshold",
           ipniVerifyMs: ipniResult.durationMs,
           ipniVerifiedAt: verifiedTimestamp.toISOString(),
-          pieceCid: deal.pieceCid,
-          ipfsRootCID: deal.metadata[ServiceType.IPFS_PIN]?.rootCID,
-          providerId: deal.storageProvider?.providerId,
-          providerAddress: deal.spAddress,
-          providerName: deal.storageProvider?.name,
           verifiedCids: ipniResult.verified,
           unverifiedCids: ipniResult.unverified,
         });


### PR DESCRIPTION
adds a log if ipniVerifyMs time is greater than 5 seconds, because it's usually a sign of a problem, and we would need to correlate logs to find the root cause.

slack chat: https://filecoinproject.slack.com/archives/C07CGTXHHT4/p1773683302799539
