### PR TITLE
fix: release-please merges are not cancelled

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,8 +7,9 @@ on:
       - pre-release
 
 concurrency:
-  group: docker-build-${{ github.ref }}
-  cancel-in-progress: true
+  # Release-please merges must complete so later retagging can find the sha image.
+  group: ${{ github.ref_name == 'main' && startsWith(github.event.head_commit.message, 'chore: release to production') && format('docker-build-release-{0}', github.sha) || format('docker-build-{0}', github.ref) }}
+  cancel-in-progress: ${{ !(github.ref_name == 'main' && startsWith(github.event.head_commit.message, 'chore: release to production')) }}
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
This fixes a CI concurrency bug that could cancel `release-please` merge builds on `main` before the backend/web image build completed.

**Issue**
`Build and Push Docker Images` used a shared concurrency group for all `main` pushes:

`docker-build-${{ github.ref }}` with `cancel-in-progress: true`

That allowed a normal later push to cancel a `release-please` merge build, even though the release workflow depends on that exact build producing the `sha-<commit>` image tags.

**Observed failure**
The original failing run was [Build and Push Docker Images #23147025528](https://github.com/FilOzone/dealbot/actions/runs/23147025528/attempts/1) for release commit `1326d2b7747665b3575d6dabf1968578fa23dad5`.

It was canceled with:
`Canceling since a higher priority waiting request for docker-build-refs/heads/main exists`

Because that run never finished `build-backend`, the later release workflow published the GitHub release `backend-v1.0.2` but failed to retag the backend image in [Release Please #23147087850](https://github.com/FilOzone/dealbot/actions/runs/23147087850). As a result, `ghcr.io/filozone/dealbot-backend:v1.0.2` was never created, so prod stayed on `v1.0.1`.

**Fix**
Release-please merge commits on `main` now use a unique concurrency group keyed by commit SHA, and they no longer use `cancel-in-progress`. Normal `main` and `pre-release` pushes keep the existing branch-level cancellation behavior.
