### PR TITLE
chore: fix docker build prod release yaml

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,8 +8,8 @@ on:
 
 concurrency:
   # Release-please merges must complete so later retagging can find the sha image.
-  group: ${{ github.ref_name == 'main' && startsWith(github.event.head_commit.message, 'chore: release to production') && format('docker-build-release-{0}', github.sha) || format('docker-build-{0}', github.ref) }}
-  cancel-in-progress: ${{ !(github.ref_name == 'main' && startsWith(github.event.head_commit.message, 'chore: release to production')) }}
+  group: "${{ github.ref_name == 'main' && startsWith(github.event.head_commit.message, 'chore: release to production') && format('docker-build-release-{0}', github.sha) || format('docker-build-{0}', github.ref) }}"
+  cancel-in-progress: "${{ !(github.ref_name == 'main' && startsWith(github.event.head_commit.message, 'chore: release to production')) }}"
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary

- Fix YAML parse error in `docker-build.yml` that prevents all CI builds from running
- The `concurrency.group` and `cancel-in-progress` expressions introduced in #369 contain single-quoted strings with colons (e.g. `'chore: release to production'`), which the YAML parser interprets as mapping separators
- Wraps both values in double quotes to fix the parse error

## Root cause

PR #369 added concurrency logic to `docker-build.yml` with unquoted `${{ }}` expressions. The YAML spec treats `:` followed by a space as a key-value separator, so the colon inside `'chore: release to production'` breaks parsing at line 11, column 94. GitHub reports this as "This run likely failed because of a workflow file issue" with no jobs executed.

failing run was https://github.com/FilOzone/dealbot/actions/runs/23246224341
