### PR TITLE
ci(release-please): use org PAT and remove release PR board shim

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           # PAT so release PRs trigger other workflows (auto-label, add-issues-and-prs-to-fs-project-board).
           # This PAT has the permissions outlined in https://github.com/googleapis/release-please-action?tab=readme-ov-file#workflow-permissions.
-          # Using GITHUB_TOKEN suppresses follow-on workflow runs, which would mean release please PRs wouldn't get properly labeled and added to the project board.
+          # Using GITHUB_TOKEN suppresses follow-on workflow runs, which would mean release-please PRs wouldn't get properly labeled and added to the project board.
           token: ${{ secrets.FILOZZY_RELEASE_PLEASE_PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

- Use `FILOZZY_RELEASE_PLEASE_PAT` for `googleapis/release-please-action` so release PRs are not attributed to `GITHUB_TOKEN` (which suppresses follow-on workflow runs).
- Add `issues: write` on the job per [release-please-action workflow permissions](https://github.com/googleapis/release-please-action#workflow-permissions).
- Remove the `Resolve release PR node ID` step and the `release_pr_number` / `release_pr_node_id` job outputs that only existed to feed the former `add-release-pr-to-project` job. With PAT-backed release PRs, normal PR automation (e.g. auto-label + [`add-issues-and-prs-to-fs-project-board`](.github/workflows/add-issues-and-prs-to-fs-project-board.yml)) can add release PRs to the board without this workflow calling `actions/add-to-project` directly.

Comments on the release-please step match [`filecoin-pin`](https://github.com/filecoin-project/filecoin-pin).

**Prerequisite:** Org secret `FILOZZY_RELEASE_PLEASE_PAT` must be available to this repository.

Made with [Cursor](https://cursor.com)