### PR TITLE
fix(ci): serialize release-please CI runs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,6 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     # Only run automatically if the image build workflow succeeded; manual runs skip this gate.
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    # Serialize release-please runs so concurrent Docker-build completions
+    # don't race each other and hit "tag already_exists" errors.
+    concurrency:
+      group: release-please
+      cancel-in-progress: false
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       backend_release_created: ${{ steps.release.outputs['apps/backend--release_created'] }}


### PR DESCRIPTION
[release-please CI](https://github.com/FilOzone/dealbot/actions/runs/23405348326) after https://github.com/FilOzone/dealbot/pull/391 was merged didn't create a PR cause there were a few other release-please jobs in process..  this should ensure that they run in order.

I kicked off a "Workflow dispatch" for release-please action and it built successfully: https://github.com/FilOzone/dealbot/actions/runs/23410551870..

this PR aims to prevent the need for the manual intervention going forward