### PR TITLE
fix: align approved provider lookups with the configured network

### DIFF
--- a/apps/backend/src/wallet-sdk/wallet-sdk.service.ts
+++ b/apps/backend/src/wallet-sdk/wallet-sdk.service.ts
@@ -54,20 +54,28 @@ export class WalletSdkService implements OnModuleInit {
    */
   private async initializeServices(): Promise<void> {
     const account = privateKeyToAccount(this.blockchainConfig.walletPrivateKey);
+    const chain = this.blockchainConfig.network === "mainnet" ? mainnet : calibration;
     const synapse = Synapse.create({
       account,
-      chain: this.blockchainConfig.network === "mainnet" ? mainnet : calibration,
+      chain,
       source: "dealbot",
     });
 
-    this.warmStorageService = WarmStorageService.create({
-      account,
+    this.warmStorageService = new WarmStorageService({
+      client: synapse.client,
     });
     this.spRegistry = new SPRegistryService({
       client: synapse.client,
     });
     this.paymentsService = synapse.payments;
     this.storageManager = synapse.storage;
+
+    this.logger.log({
+      event: "wallet_sdk_initialized",
+      message: "Initialized wallet SDK services",
+      network: this.blockchainConfig.network,
+      chainId: chain.id,
+    });
   }
 
   /**

--- a/kustomize/base/backend/configmap.yaml
+++ b/kustomize/base/backend/configmap.yaml
@@ -11,4 +11,5 @@ data:
   DATABASE_USER: "dealbot"
   DEALBOT_HOST: "0.0.0.0"
   DEALBOT_PORT: "3130"
+  NETWORK: "mainnet"
   NODE_ENV: "production"


### PR DESCRIPTION
## Summary

- initialize `WarmStorageService` from `synapse.client` so approved provider IDs are fetched from the same chain as the rest of the backend
- set the backend base config `NETWORK` to `mainnet` for production-oriented deployments
- add a startup log for the selected network and chain ID

## Why

The https://dealbot.filoz.org site is showing approval status from calibnet because `WarmStorageService` was created without an explicit chain, so the SDK defaulted to calibration even when the backend was otherwise using mainnet.