### PR TITLE
fix: make dataset provisioning idempotent after partial failures

### DIFF
--- a/apps/backend/src/deal/deal.service.spec.ts
+++ b/apps/backend/src/deal/deal.service.spec.ts
@@ -963,7 +963,7 @@ describe("DealService", () => {
     it("creates dataset with piece via createContext + executeUpload", async () => {
       vi.spyOn(mockWalletSdkService, "getProviderInfo").mockReturnValue(mockProviderInfo);
 
-      const createContextMock = vi.fn().mockResolvedValue({ dataSetId: 42 });
+      const createContextMock = vi.fn().mockResolvedValue({ dataSetId: undefined });
       const synapseMock = {
         storage: { createContext: createContextMock },
       } as unknown as Synapse;
@@ -985,6 +985,7 @@ describe("DealService", () => {
         expect.any(Uint8Array),
         expect.any(Object),
         expect.objectContaining({
+          providerIds: [101n],
           pieceMetadata: {},
           ipniValidation: { enabled: false },
         }),
@@ -1004,7 +1005,7 @@ describe("DealService", () => {
 
     it("does not invoke data-storage-check metrics or Deal persistence", async () => {
       vi.spyOn(mockWalletSdkService, "getProviderInfo").mockReturnValue(mockProviderInfo);
-      const createContextMock = vi.fn().mockResolvedValue({ dataSetId: 1 });
+      const createContextMock = vi.fn().mockResolvedValue({ dataSetId: undefined });
       vi.spyOn(service as any, "createSynapseInstance").mockImplementation(
         () =>
           ({
@@ -1025,12 +1026,30 @@ describe("DealService", () => {
       expect(dataSourceMock.generateRandomDataset).not.toHaveBeenCalled();
     });
 
+    it("returns success without uploading when the data set already exists", async () => {
+      vi.spyOn(mockWalletSdkService, "getProviderInfo").mockReturnValue(mockProviderInfo);
+      vi.spyOn(service as any, "createSynapseInstance").mockImplementation(
+        () =>
+          ({
+            storage: { createContext: vi.fn().mockResolvedValue({ dataSetId: 42 }) },
+          }) as unknown as Synapse,
+      );
+
+      await expect(service.createDataSetWithPiece("0xprovider", {})).resolves.toBeUndefined();
+
+      expect(executeUpload).not.toHaveBeenCalled();
+      expect(mockDataSetCreationMetrics.recordStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ checkType: "dataSetCreation" }),
+        "success",
+      );
+    });
+
     it("fails when upload completes without a pieceCid", async () => {
       vi.spyOn(mockWalletSdkService, "getProviderInfo").mockReturnValue(mockProviderInfo);
       vi.spyOn(service as any, "createSynapseInstance").mockImplementation(
         () =>
           ({
-            storage: { createContext: vi.fn().mockResolvedValue({ dataSetId: 1 }) },
+            storage: { createContext: vi.fn().mockResolvedValue({ dataSetId: undefined }) },
           }) as unknown as Synapse,
       );
 
@@ -1054,7 +1073,7 @@ describe("DealService", () => {
       vi.spyOn(service as any, "createSynapseInstance").mockImplementation(
         () =>
           ({
-            storage: { createContext: vi.fn().mockResolvedValue({ dataSetId: 1 }) },
+            storage: { createContext: vi.fn().mockResolvedValue({ dataSetId: undefined }) },
           }) as unknown as Synapse,
       );
 
@@ -1069,12 +1088,39 @@ describe("DealService", () => {
       );
     });
 
+    it("treats upload failure as success when reconciliation finds the data set", async () => {
+      vi.spyOn(mockWalletSdkService, "getProviderInfo").mockReturnValue(mockProviderInfo);
+      const createContextMock = vi
+        .fn()
+        .mockResolvedValueOnce({ dataSetId: undefined })
+        .mockResolvedValueOnce({ dataSetId: 42 });
+      vi.spyOn(service as any, "createSynapseInstance").mockImplementation(
+        () =>
+          ({
+            storage: { createContext: createContextMock },
+          }) as unknown as Synapse,
+      );
+      (executeUpload as Mock).mockRejectedValue(new Error("HTTP 429"));
+
+      await expect(service.createDataSetWithPiece("0xprovider", {})).resolves.toBeUndefined();
+
+      expect(createContextMock).toHaveBeenCalledTimes(2);
+      expect(mockDataSetCreationMetrics.recordStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ checkType: "dataSetCreation" }),
+        "success",
+      );
+      expect(mockDataSetCreationMetrics.recordStatus).not.toHaveBeenCalledWith(
+        expect.objectContaining({ checkType: "dataSetCreation" }),
+        "failure.other",
+      );
+    });
+
     it("aborts when signal is aborted during upload", async () => {
       vi.spyOn(mockWalletSdkService, "getProviderInfo").mockReturnValue(mockProviderInfo);
       vi.spyOn(service as any, "createSynapseInstance").mockImplementation(
         () =>
           ({
-            storage: { createContext: vi.fn().mockResolvedValue({ dataSetId: 1 }) },
+            storage: { createContext: vi.fn().mockResolvedValue({ dataSetId: undefined }) },
           }) as unknown as Synapse,
       );
 

--- a/apps/backend/src/deal/deal.service.ts
+++ b/apps/backend/src/deal/deal.service.ts
@@ -496,7 +496,7 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
       signal,
     );
     signal?.throwIfAborted();
-    return context.dataSetId !== undefined;
+    return context.dataSetId != null;
   }
 
   /**
@@ -535,14 +535,15 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
       metadata,
     });
 
+    const synapse = this.sharedSynapse ?? this.createSynapseInstance();
     let pieceAdded = false;
     let piecesConfirmed = false;
     let pieceCid: string | undefined;
     let pieceId: number | undefined;
     let transactionHash: string | undefined;
+    let dataSetId: bigint | number | string | undefined;
 
     try {
-      const synapse = this.sharedSynapse ?? this.createSynapseInstance();
       signal?.throwIfAborted();
 
       const DATA_SET_CREATION_PIECE_SIZE = 200 * 1024; // 200 KiB
@@ -564,6 +565,23 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
         signal,
       );
       signal?.throwIfAborted();
+      dataSetId = storage.dataSetId ?? undefined;
+
+      if (dataSetId != null) {
+        const durationMs = Date.now() - startedAt;
+        this.dataSetCreationMetrics.observeCheckDuration(labels, durationMs);
+        this.dataSetCreationMetrics.recordStatus(labels, "success");
+        this.logger.log({
+          event: "dataset_creation_already_exists",
+          message: "Data-set already exists; skipping seed piece upload",
+          providerAddress,
+          providerId: providerInfo.id,
+          providerName: providerInfo.name,
+          durationMs,
+          dataSetId,
+        });
+        return;
+      }
 
       const filecoinPinLogger = createFilecoinPinLogger(this.logger);
 
@@ -572,8 +590,7 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
           logger: filecoinPinLogger,
           contextId: providerAddress,
           copies: 1,
-          // SDK forbids specifying both dataSetIds and providerIds — use one or the other
-          ...(storage.dataSetId != null ? { dataSetIds: [storage.dataSetId] } : { providerIds: [providerInfo.id] }),
+          providerIds: [providerInfo.id],
           pieceMetadata: {},
           ipniValidation: { enabled: false },
           onProgress: async (event) => {
@@ -650,7 +667,7 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
         providerId: providerInfo.id,
         providerName: providerInfo.name,
         durationMs,
-        dataSetId: storage.dataSetId ?? "unknown",
+        dataSetId: dataSetId ?? "unknown",
         pieceCid: pieceCid ?? "unknown",
         pieceId: pieceId ?? "unknown",
         txHash: transactionHash ?? "unknown",
@@ -658,8 +675,38 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
         piecesConfirmed,
       });
     } catch (error) {
+      dataSetId = await this.recoverProvisionedDataSetId(synapse, providerInfo, metadata, {
+        providerAddress,
+        pieceAdded,
+        piecesConfirmed,
+        pieceCid,
+        pieceId,
+        transactionHash,
+      });
+
       const durationMs = Date.now() - startedAt;
       this.dataSetCreationMetrics.observeCheckDuration(labels, durationMs);
+
+      if (dataSetId != null) {
+        this.dataSetCreationMetrics.recordStatus(labels, "success");
+        this.logger.warn({
+          event: "dataset_creation_reconciled_after_failure",
+          message: "Data-set creation failed locally but data-set now exists; treating as success",
+          providerAddress,
+          providerId: providerInfo.id,
+          providerName: providerInfo.name,
+          durationMs,
+          dataSetId,
+          pieceAdded,
+          piecesConfirmed,
+          pieceCid,
+          pieceId,
+          transactionHash,
+          error: toStructuredError(error),
+        });
+        return;
+      }
+
       this.dataSetCreationMetrics.recordStatus(labels, classifyFailureStatus(error));
       this.logger.error({
         event: "dataset_creation_with_piece_failed",
@@ -668,6 +715,7 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
         providerId: providerInfo.id,
         providerName: providerInfo.name,
         durationMs,
+        dataSetId,
         pieceAdded,
         piecesConfirmed,
         pieceCid,
@@ -676,6 +724,43 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
         error: toStructuredError(error),
       });
       throw error;
+    }
+  }
+
+  private async recoverProvisionedDataSetId(
+    synapse: Synapse,
+    providerInfo: PDPProviderEx,
+    metadata: Record<string, string>,
+    context: {
+      providerAddress: string;
+      pieceAdded: boolean;
+      piecesConfirmed: boolean;
+      pieceCid?: string;
+      pieceId?: number;
+      transactionHash?: string;
+    },
+  ): Promise<bigint | number | string | undefined> {
+    try {
+      const recovered = await synapse.storage.createContext({
+        providerId: providerInfo.id,
+        metadata,
+      });
+      return recovered.dataSetId ?? undefined;
+    } catch (recoveryError) {
+      this.logger.warn({
+        event: "dataset_creation_reconciliation_failed",
+        message: "Unable to reconcile data-set existence after failed seed upload",
+        providerAddress: context.providerAddress,
+        providerId: providerInfo.id,
+        providerName: providerInfo.name,
+        pieceAdded: context.pieceAdded,
+        piecesConfirmed: context.piecesConfirmed,
+        pieceCid: context.pieceCid,
+        pieceId: context.pieceId,
+        transactionHash: context.transactionHash,
+        error: toStructuredError(recoveryError),
+      });
+      return undefined;
     }
   }
 


### PR DESCRIPTION
## Summary

DealBot dataset provisioning was not fully idempotent.

`createDataSetWithPiece()` is only meant to ensure a dataset exists, but it could still:
- upload a new seed piece even when `createContext()` had already resolved an existing dataset
- treat partial upload failures as hard failures, even if the dataset had actually been created and would be found on the next lookup

That behavior could cause the scheduled dataset creation job to keep retrying and burn balance faster than expected.

## Changes

- Return success immediately when `createContext()` already returns a `dataSetId`
- Skip the seed-piece upload in that case
- After `executeUpload()` fails, re-run `createContext()` to reconcile dataset existence
- Treat reconciliation success as job success instead of retrying provisioning again later
- Tighten dataset existence checks to treat any non-null `dataSetId` as existing
- Add unit tests covering:
  - existing dataset short-circuit
  - successful upload path when no dataset exists
  - reconciliation after an upload failure such as a `429`

## Why this helps

This makes dataset provisioning behave more like an idempotent “ensure exists” operation.

If a dataset was already present, or if it was created despite a local/upload-side failure, DealBot now stops retrying that provisioning path and avoids extra chargeable dataset churn.