### PR TITLE
fix: add missing backend-resources-local.yaml

### DIFF
--- a/kustomize/overlays/local/backend-resources-local.yaml
+++ b/kustomize/overlays/local/backend-resources-local.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dealbot
+spec:
+  template:
+    spec:
+      containers:
+        - name: dealbot
+          resources:
+            limits:
+              cpu: "1"
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi


### PR DESCRIPTION
Commit e781e76  added backend-resources-local.yaml to kustomization.yaml but never committed the file itself. This PR adds a sensible default.