### PR TITLE
fix: capture full error cause stacks

### DIFF
--- a/apps/backend/src/common/logging.spec.ts
+++ b/apps/backend/src/common/logging.spec.ts
@@ -50,6 +50,37 @@ describe("toStructuredError", () => {
     expect(result.stack!.length).toBeLessThan(longStack.length);
   });
 
+  it("serializes error cause chains", () => {
+    const root = new Error("connection reset");
+    const mid = new Error("fetch failed", { cause: root });
+    const top = new Error("store failed", { cause: mid });
+
+    const result = toStructuredError(top);
+
+    expect(result.cause).toBeDefined();
+    expect(result.cause!.message).toBe("fetch failed");
+    expect(result.cause!.cause).toBeDefined();
+    expect(result.cause!.cause!.message).toBe("connection reset");
+    expect(result.cause!.cause!.cause).toBeUndefined();
+  });
+
+  it("limits cause depth to prevent infinite recursion", () => {
+    let error: Error = new Error("root");
+    for (let i = 0; i < 10; i++) {
+      error = new Error(`level-${i}`, { cause: error });
+    }
+
+    const result = toStructuredError(error);
+
+    let depth = 0;
+    let current: typeof result | undefined = result;
+    while (current?.cause) {
+      depth++;
+      current = current.cause;
+    }
+    expect(depth).toBeLessThanOrEqual(5);
+  });
+
   it("serializes non-Error payloads and preserves bigint values as strings", () => {
     const payload = { a: 1n, nested: { ok: true } };
 

--- a/apps/backend/src/common/logging.ts
+++ b/apps/backend/src/common/logging.ts
@@ -8,6 +8,7 @@ export type StructuredError = {
   code?: string;
   stack?: string;
   details?: unknown;
+  cause?: StructuredError;
 };
 
 export function toJsonSafe(value: unknown): unknown {
@@ -29,14 +30,22 @@ function truncateErrorStack(stack: string | undefined): string | undefined {
   return `${stack.slice(0, MAX_ERROR_STACK_LENGTH)}... [truncated ${omittedChars} chars]`;
 }
 
+const MAX_CAUSE_DEPTH = 5;
+
 /**
  * Serializes unknown error values into structured JSON-friendly fields.
+ * Recursively serializes error.cause chains up to MAX_CAUSE_DEPTH levels.
  */
-export function toStructuredError(error: unknown): StructuredError {
+export function toStructuredError(error: unknown, depth: number = 0): StructuredError {
   if (error instanceof Error) {
     const typedError = error as ErrorWithCode;
     const rawCode = typedError.code;
     const stringCode = rawCode === null || rawCode === undefined ? undefined : String(rawCode);
+
+    const cause =
+      error.cause instanceof Error && depth < MAX_CAUSE_DEPTH
+        ? toStructuredError(error.cause, depth + 1)
+        : undefined;
 
     return {
       type: "error",
@@ -44,6 +53,7 @@ export function toStructuredError(error: unknown): StructuredError {
       message: error.message,
       code: stringCode && stringCode.length > 0 ? stringCode : undefined,
       stack: truncateErrorStack(error.stack),
+      cause,
     };
   }
 

--- a/apps/backend/src/common/logging.ts
+++ b/apps/backend/src/common/logging.ts
@@ -43,9 +43,7 @@ export function toStructuredError(error: unknown, depth: number = 0): Structured
     const stringCode = rawCode === null || rawCode === undefined ? undefined : String(rawCode);
 
     const cause =
-      error.cause instanceof Error && depth < MAX_CAUSE_DEPTH
-        ? toStructuredError(error.cause, depth + 1)
-        : undefined;
+      error.cause instanceof Error && depth < MAX_CAUSE_DEPTH ? toStructuredError(error.cause, depth + 1) : undefined;
 
     return {
       type: "error",

--- a/apps/backend/src/common/logging.ts
+++ b/apps/backend/src/common/logging.ts
@@ -43,7 +43,7 @@ export function toStructuredError(error: unknown, depth: number = 0): Structured
     const stringCode = rawCode === null || rawCode === undefined ? undefined : String(rawCode);
 
     const cause =
-      error.cause instanceof Error && depth < MAX_CAUSE_DEPTH ? toStructuredError(error.cause, depth + 1) : undefined;
+      error.cause !== undefined && depth < MAX_CAUSE_DEPTH ? toStructuredError(error.cause, depth + 1) : undefined;
 
     return {
       type: "error",


### PR DESCRIPTION
Synapse in particular uses wrapped errors with cause and they are being missed