### PR TITLE
fix: redact RPC tokens from logged deal errors

### DIFF
--- a/apps/backend/src/common/logging.spec.ts
+++ b/apps/backend/src/common/logging.spec.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { toStructuredError } from "./logging.js";
+import { redactSensitiveText, toStructuredError } from "./logging.js";
 
 describe("toStructuredError", () => {
+  it("redacts sensitive credentials from URLs in plain text", () => {
+    expect(
+      redactSensitiveText("URL: https://user:pass@example.com/rpc/v1?token=secret&api_key=another&ok=1"),
+    ).toBe("URL: https://REDACTED:REDACTED@example.com/rpc/v1?token=REDACTED&api_key=REDACTED&ok=1");
+  });
+
   it("serializes Error instances into structured fields", () => {
     const error = Object.assign(new Error("boom"), { code: "E_BOOM" });
 
@@ -23,6 +29,28 @@ describe("toStructuredError", () => {
       type: "non_error",
       message: "failure",
     });
+  });
+
+  it("redacts sensitive URLs from error messages, stacks, and causes", () => {
+    const cause = new Error("URL: https://example.com/rpc?access_token=cause-secret");
+    const error = new Error("URL: https://example.com/rpc?token=top-secret&ok=1", { cause });
+    error.stack = `Error: request failed\nURL: https://example.com/rpc?apikey=stack-secret`;
+
+    const result = toStructuredError(error);
+
+    expect(result.message).toContain("token=REDACTED");
+    expect(result.message).toContain("ok=1");
+    expect(result.message).not.toContain("top-secret");
+    expect(result.stack).toContain("apikey=REDACTED");
+    expect(result.stack).not.toContain("stack-secret");
+    expect(result.cause?.message).toContain("access_token=REDACTED");
+    expect(result.cause?.message).not.toContain("cause-secret");
+  });
+
+  it("redacts sensitive URLs from thrown strings", () => {
+    expect(toStructuredError("URL: https://example.com/rpc?authorization=secret").message).toContain(
+      "authorization=REDACTED",
+    );
   });
 
   it("normalizes non-string error codes to strings", () => {

--- a/apps/backend/src/common/logging.spec.ts
+++ b/apps/backend/src/common/logging.spec.ts
@@ -8,6 +8,12 @@ describe("toStructuredError", () => {
     );
   });
 
+  it("preserves username-only URL shape when redacting credentials", () => {
+    expect(redactSensitiveText("URL: https://user@example.com/rpc/v1?token=secret")).toBe(
+      "URL: https://REDACTED@example.com/rpc/v1?token=REDACTED",
+    );
+  });
+
   it("serializes Error instances into structured fields", () => {
     const error = Object.assign(new Error("boom"), { code: "E_BOOM" });
 
@@ -76,6 +82,17 @@ describe("toStructuredError", () => {
     expect(result.stack).toContain("Error: boom");
     expect(result.stack).toContain("[truncated ");
     expect(result.stack!.length).toBeLessThan(longStack.length);
+  });
+
+  it("redacts sensitive URLs near the stack truncation boundary", () => {
+    const error = new Error("boom");
+    error.stack = `${"x".repeat(4020)} https://example.com/rpc?token=stack-secret ${"y".repeat(200)}`;
+
+    const result = toStructuredError(error);
+
+    expect(result.stack).toContain("token=REDACTED");
+    expect(result.stack).not.toContain("stack-secret");
+    expect(result.stack).toContain("[truncated ");
   });
 
   it("serializes error cause chains", () => {

--- a/apps/backend/src/common/logging.spec.ts
+++ b/apps/backend/src/common/logging.spec.ts
@@ -3,9 +3,9 @@ import { redactSensitiveText, toStructuredError } from "./logging.js";
 
 describe("toStructuredError", () => {
   it("redacts sensitive credentials from URLs in plain text", () => {
-    expect(
-      redactSensitiveText("URL: https://user:pass@example.com/rpc/v1?token=secret&api_key=another&ok=1"),
-    ).toBe("URL: https://REDACTED:REDACTED@example.com/rpc/v1?token=REDACTED&api_key=REDACTED&ok=1");
+    expect(redactSensitiveText("URL: https://user:pass@example.com/rpc/v1?token=secret&api_key=another&ok=1")).toBe(
+      "URL: https://REDACTED:REDACTED@example.com/rpc/v1?token=REDACTED&api_key=REDACTED&ok=1",
+    );
   });
 
   it("serializes Error instances into structured fields", () => {

--- a/apps/backend/src/common/logging.ts
+++ b/apps/backend/src/common/logging.ts
@@ -1,5 +1,6 @@
 type ErrorWithCode = Error & { code?: unknown };
 const MAX_ERROR_STACK_LENGTH = 4 * 1024;
+const ERROR_STACK_REDACTION_BUFFER_LENGTH = 512;
 const MAX_CAUSE_DEPTH = 5;
 const URL_PATTERN = /\bhttps?:\/\/[^\s<>"')\]}]+/gi;
 const REDACTED_VALUE = "REDACTED";
@@ -29,8 +30,11 @@ function redactSensitiveUrl(url: string): string {
   try {
     const parsed = new URL(url);
 
-    if (parsed.username || parsed.password) {
+    if (parsed.username) {
       parsed.username = REDACTED_VALUE;
+    }
+
+    if (parsed.password) {
       parsed.password = REDACTED_VALUE;
     }
 
@@ -50,13 +54,24 @@ export function redactSensitiveText(text: string): string {
   return text.replaceAll(URL_PATTERN, redactSensitiveUrl);
 }
 
-function truncateErrorStack(stack: string | undefined): string | undefined {
+function truncateErrorStack(stack: string): string {
   if (!stack || stack.length <= MAX_ERROR_STACK_LENGTH) {
     return stack;
   }
 
   const omittedChars = stack.length - MAX_ERROR_STACK_LENGTH;
   return `${stack.slice(0, MAX_ERROR_STACK_LENGTH)}... [truncated ${omittedChars} chars]`;
+}
+
+function redactErrorStack(stack: string | undefined): string | undefined {
+  if (!stack) {
+    return stack;
+  }
+
+  const redactionWindow = MAX_ERROR_STACK_LENGTH + ERROR_STACK_REDACTION_BUFFER_LENGTH;
+  const boundedStack = stack.length > redactionWindow ? stack.slice(0, redactionWindow) : stack;
+
+  return truncateErrorStack(redactSensitiveText(boundedStack));
 }
 
 /**
@@ -77,7 +92,7 @@ export function toStructuredError(error: unknown, depth: number = 0): Structured
       name: error.name,
       message: redactSensitiveText(error.message),
       code: stringCode && stringCode.length > 0 ? stringCode : undefined,
-      stack: truncateErrorStack(error.stack ? redactSensitiveText(error.stack) : undefined),
+      stack: redactErrorStack(error.stack),
       cause,
     };
   }

--- a/apps/backend/src/common/logging.ts
+++ b/apps/backend/src/common/logging.ts
@@ -1,5 +1,15 @@
 type ErrorWithCode = Error & { code?: unknown };
 const MAX_ERROR_STACK_LENGTH = 4 * 1024;
+const MAX_CAUSE_DEPTH = 5;
+const URL_PATTERN = /\bhttps?:\/\/[^\s<>"')\]}]+/gi;
+const REDACTED_VALUE = "REDACTED";
+const SENSITIVE_QUERY_PARAMETER_NAMES = new Set([
+  "token",
+  "api_key",
+  "apikey",
+  "access_token",
+  "authorization",
+]);
 
 export type StructuredError = {
   type: "error" | "non_error";
@@ -21,6 +31,31 @@ export function toJsonSafe(value: unknown): unknown {
   }
 }
 
+function redactSensitiveUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+
+    if (parsed.username || parsed.password) {
+      parsed.username = REDACTED_VALUE;
+      parsed.password = REDACTED_VALUE;
+    }
+
+    for (const key of parsed.searchParams.keys()) {
+      if (SENSITIVE_QUERY_PARAMETER_NAMES.has(key.toLowerCase())) {
+        parsed.searchParams.set(key, REDACTED_VALUE);
+      }
+    }
+
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+export function redactSensitiveText(text: string): string {
+  return text.replace(URL_PATTERN, redactSensitiveUrl);
+}
+
 function truncateErrorStack(stack: string | undefined): string | undefined {
   if (!stack || stack.length <= MAX_ERROR_STACK_LENGTH) {
     return stack;
@@ -29,8 +64,6 @@ function truncateErrorStack(stack: string | undefined): string | undefined {
   const omittedChars = stack.length - MAX_ERROR_STACK_LENGTH;
   return `${stack.slice(0, MAX_ERROR_STACK_LENGTH)}... [truncated ${omittedChars} chars]`;
 }
-
-const MAX_CAUSE_DEPTH = 5;
 
 /**
  * Serializes unknown error values into structured JSON-friendly fields.
@@ -48,9 +81,9 @@ export function toStructuredError(error: unknown, depth: number = 0): Structured
     return {
       type: "error",
       name: error.name,
-      message: error.message,
+      message: redactSensitiveText(error.message),
       code: stringCode && stringCode.length > 0 ? stringCode : undefined,
-      stack: truncateErrorStack(error.stack),
+      stack: truncateErrorStack(error.stack ? redactSensitiveText(error.stack) : undefined),
       cause,
     };
   }
@@ -58,7 +91,7 @@ export function toStructuredError(error: unknown, depth: number = 0): Structured
   if (typeof error === "string") {
     return {
       type: "non_error",
-      message: error,
+      message: redactSensitiveText(error),
     };
   }
 

--- a/apps/backend/src/common/logging.ts
+++ b/apps/backend/src/common/logging.ts
@@ -47,7 +47,7 @@ function redactSensitiveUrl(url: string): string {
 }
 
 export function redactSensitiveText(text: string): string {
-  return text.replace(URL_PATTERN, redactSensitiveUrl);
+  return text.replaceAll(URL_PATTERN, redactSensitiveUrl);
 }
 
 function truncateErrorStack(stack: string | undefined): string | undefined {

--- a/apps/backend/src/common/logging.ts
+++ b/apps/backend/src/common/logging.ts
@@ -3,13 +3,7 @@ const MAX_ERROR_STACK_LENGTH = 4 * 1024;
 const MAX_CAUSE_DEPTH = 5;
 const URL_PATTERN = /\bhttps?:\/\/[^\s<>"')\]}]+/gi;
 const REDACTED_VALUE = "REDACTED";
-const SENSITIVE_QUERY_PARAMETER_NAMES = new Set([
-  "token",
-  "api_key",
-  "apikey",
-  "access_token",
-  "authorization",
-]);
+const SENSITIVE_QUERY_PARAMETER_NAMES = new Set(["token", "api_key", "apikey", "access_token", "authorization"]);
 
 export type StructuredError = {
   type: "error" | "non_error";

--- a/apps/backend/src/common/logging.ts
+++ b/apps/backend/src/common/logging.ts
@@ -42,7 +42,7 @@ function redactSensitiveUrl(url: string): string {
 
     return parsed.toString();
   } catch {
-    return url;
+    return `INVALID_URL[${url}]`;
   }
 }
 

--- a/apps/backend/src/deal/deal.service.spec.ts
+++ b/apps/backend/src/deal/deal.service.spec.ts
@@ -550,6 +550,26 @@ describe("DealService", () => {
       expect(dealRepoMock.save).toHaveBeenCalledWith(mockDeal);
     });
 
+    it("redacts sensitive RPC credentials before persisting deal failures", async () => {
+      const error = new Error("HTTP request failed.\nURL: https://filecoin.chain.love/rpc/v1?token=secret-token&ok=1");
+      const uploadPayload = {
+        carData: Uint8Array.from([1, 2, 3]),
+        rootCid: CID.parse(mockRootCid),
+      };
+
+      createContextMock.mockRejectedValue(error);
+
+      await expect(
+        service.createDeal(mockSynapseInstance, mockProviderInfo, mockDealInput, uploadPayload),
+      ).rejects.toThrow("secret-token");
+
+      expect(mockDeal.status).toBe(DealStatus.FAILED);
+      expect(mockDeal.errorMessage).toContain("token=REDACTED");
+      expect(mockDeal.errorMessage).toContain("ok=1");
+      expect(mockDeal.errorMessage).not.toContain("secret-token");
+      expect(dealRepoMock.save).toHaveBeenCalledWith(mockDeal);
+    });
+
     it("records abort reasons when signal aborts with a non-Error value", async () => {
       const uploadPayload = {
         carData: Uint8Array.from([1, 2, 3]),

--- a/apps/backend/src/deal/deal.service.ts
+++ b/apps/backend/src/deal/deal.service.ts
@@ -9,7 +9,7 @@ import type { Repository } from "typeorm";
 import { awaitWithAbort } from "../common/abort-utils.js";
 import { buildUnixfsCar } from "../common/car-utils.js";
 import { createFilecoinPinLogger } from "../common/filecoin-pin-logger.js";
-import { type DealLogContext, type ProviderJobContext, toStructuredError } from "../common/logging.js";
+import { redactSensitiveText, type DealLogContext, type ProviderJobContext, toStructuredError } from "../common/logging.js";
 import { createSynapseFromConfig } from "../common/synapse-factory.js";
 import type { DataFile, Hex } from "../common/types.js";
 import type { IBlockchainConfig, IConfig } from "../config/app.config.js";
@@ -437,7 +437,7 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
 
       return deal;
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = redactSensitiveText(error instanceof Error ? error.message : String(error));
       this.logger.error({
         ...dealLogContext,
         event: "deal_creation_failed",

--- a/apps/backend/src/deal/deal.service.ts
+++ b/apps/backend/src/deal/deal.service.ts
@@ -9,7 +9,12 @@ import type { Repository } from "typeorm";
 import { awaitWithAbort } from "../common/abort-utils.js";
 import { buildUnixfsCar } from "../common/car-utils.js";
 import { createFilecoinPinLogger } from "../common/filecoin-pin-logger.js";
-import { redactSensitiveText, type DealLogContext, type ProviderJobContext, toStructuredError } from "../common/logging.js";
+import {
+  type DealLogContext,
+  type ProviderJobContext,
+  redactSensitiveText,
+  toStructuredError,
+} from "../common/logging.js";
 import { createSynapseFromConfig } from "../common/synapse-factory.js";
 import type { DataFile, Hex } from "../common/types.js";
 import type { IBlockchainConfig, IConfig } from "../config/app.config.js";


### PR DESCRIPTION
## What changed
- redact sensitive credentials from URLs embedded in structured error messages and stacks
- persist a redacted deal failure message instead of the raw upstream error text
- add regression tests covering log serialization and failed deal persistence

## Why
A `429` from the configured Filecoin RPC can bubble up through `viem` with the full request URL in the error message. Dealbot was forwarding that raw message into logs and into `deals.error_message`, which could expose RPC query-string tokens.

## Impact
This keeps the existing error flow intact while replacing values for sensitive URL credentials and query parameters like `token`, `api_key`, `apikey`, `access_token`, and `authorization` with `REDACTED` in the affected dealbot surfaces.

## Root cause
`viem` includes the full request URL in `HttpRequestError` / `ContractFunctionExecutionError` messages, and dealbot was serializing and persisting `error.message` without any redaction.

## Validation
- `pnpm test -- logging.spec.ts deal.service.spec.ts` (backend suite passed)
- `pnpm typecheck`
