### PR TITLE
fix: skip address-blocked jobs before context resolution

### DIFF
--- a/apps/backend/src/jobs/jobs.service.spec.ts
+++ b/apps/backend/src/jobs/jobs.service.spec.ts
@@ -1518,4 +1518,73 @@ describe("JobsService schedule rows", () => {
 
     expect(dealService.createDataSetWithPiece).not.toHaveBeenCalled();
   });
+
+  it("SP jobs skip address-blocked providers before resolving missing provider context", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T12:00:00Z"));
+
+    baseConfigValues.spBlocklists = { ids: new Set(), addresses: new Set(["0xaaa"]) };
+
+    const completedCounter = metricsMocks.jobsCompletedCounter as unknown as { inc: ReturnType<typeof vi.fn> };
+    const dealService = {
+      createDealForProvider: vi.fn(),
+      getBaseDataSetMetadata: vi.fn(() => ({})),
+    };
+    const retrievalService = { performRandomRetrievalForProvider: vi.fn() };
+    const dataSetDealService = {
+      getBaseDataSetMetadata: vi.fn(() => ({})),
+      checkDataSetExists: vi.fn(async () => false),
+      createDataSetWithPiece: vi.fn(async () => {}),
+    };
+    const walletSdkService = {
+      getTestingProviders: vi.fn(() => []),
+      getProviderInfo: vi.fn(() => undefined),
+      loadProviders: vi.fn(),
+    };
+
+    const cases = [
+      {
+        handler: "handleDealJob",
+        jobType: "deal",
+        intervalSeconds: 60,
+        service: buildService({
+          dealService: dealService as unknown as JobsServiceDeps[3],
+          walletSdkService: walletSdkService as unknown as JobsServiceDeps[6],
+        }),
+        expectCheckNotRun: () => expect(dealService.createDealForProvider).not.toHaveBeenCalled(),
+      },
+      {
+        handler: "handleRetrievalJob",
+        jobType: "retrieval",
+        intervalSeconds: 60,
+        service: buildService({
+          retrievalService: retrievalService as unknown as JobsServiceDeps[4],
+          walletSdkService: walletSdkService as unknown as JobsServiceDeps[6],
+        }),
+        expectCheckNotRun: () => expect(retrievalService.performRandomRetrievalForProvider).not.toHaveBeenCalled(),
+      },
+      {
+        handler: "handleDataSetCreationJob",
+        jobType: "data_set_creation",
+        intervalSeconds: 3600,
+        service: buildService({
+          dealService: dataSetDealService as unknown as JobsServiceDeps[3],
+          walletSdkService: walletSdkService as unknown as JobsServiceDeps[6],
+        }),
+        expectCheckNotRun: () => expect(dataSetDealService.createDataSetWithPiece).not.toHaveBeenCalled(),
+      },
+    ];
+
+    for (const testCase of cases) {
+      await callPrivate(testCase.service, testCase.handler, {
+        id: `job-address-blocked-${testCase.jobType}`,
+        data: { jobType: testCase.jobType, spAddress: "0xaaa", intervalSeconds: testCase.intervalSeconds },
+      });
+
+      testCase.expectCheckNotRun();
+      expect(completedCounter.inc).toHaveBeenCalledWith({ job_type: testCase.jobType, handler_result: "success" });
+    }
+
+    expect(storageProviderRepositoryMock.findOne).not.toHaveBeenCalled();
+  });
 });

--- a/apps/backend/src/jobs/jobs.service.ts
+++ b/apps/backend/src/jobs/jobs.service.ts
@@ -411,6 +411,36 @@ export class JobsService implements OnModuleInit, OnApplicationShutdown {
     };
   }
 
+  private async resolveRunnableProviderJobContext(
+    jobType: SpJobType,
+    spAddress: string,
+    jobId: string,
+    message: string,
+  ): Promise<ProviderJobContext | null> {
+    const spBlocklists = this.configService.get<ISpBlocklistConfig>("spBlocklists");
+    if (isSpBlocked(spBlocklists, spAddress)) {
+      this.logger.log({
+        jobId,
+        providerAddress: spAddress,
+        event: `${jobType}_job_blocked`,
+        message,
+      });
+      return null;
+    }
+
+    const logContext = await this.resolveProviderJobContext(spAddress, jobId);
+    if (isSpBlocked(spBlocklists, spAddress, logContext.providerId)) {
+      this.logger.log({
+        ...logContext,
+        event: `${jobType}_job_blocked`,
+        message,
+      });
+      return null;
+    }
+
+    return logContext;
+  }
+
   private logMaintenanceSkip(taskLabel: string, windowLabel?: string, logContext?: Partial<JobLogContext>) {
     const scheduling = this.configService.get("scheduling");
     const label = windowLabel ?? "unknown";
@@ -448,7 +478,13 @@ export class JobsService implements OnModuleInit, OnApplicationShutdown {
     }, timeoutMs);
 
     await this.recordJobExecution("deal", async () => {
-      const logContext = await this.resolveProviderJobContext(spAddress, job.id);
+      const logContext = await this.resolveRunnableProviderJobContext(
+        "deal",
+        spAddress,
+        job.id,
+        "Deal job skipped: provider is blocked for scheduled data-storage checks",
+      );
+      if (logContext == null) return "success";
       try {
         let provider = this.walletSdkService.getTestingProviders().find((p) => p.serviceProvider === spAddress);
         if (!provider) {
@@ -464,15 +500,6 @@ export class JobsService implements OnModuleInit, OnApplicationShutdown {
             });
             return "success";
           }
-        }
-
-        if (isSpBlocked(this.configService.get("spBlocklists"), provider.serviceProvider, logContext.providerId)) {
-          this.logger.log({
-            ...logContext,
-            event: "deal_job_blocked",
-            message: "Deal job skipped: provider is blocked for scheduled data-storage checks",
-          });
-          return "success";
         }
 
         // Data-set-aware deal creation
@@ -584,16 +611,14 @@ export class JobsService implements OnModuleInit, OnApplicationShutdown {
     }, timeoutMs);
 
     await this.recordJobExecution("retrieval", async () => {
-      const logContext = await this.resolveProviderJobContext(spAddress, job.id);
+      const logContext = await this.resolveRunnableProviderJobContext(
+        "retrieval",
+        spAddress,
+        job.id,
+        "Retrieval job skipped: provider is blocked for scheduled retrieval checks",
+      );
+      if (logContext == null) return "success";
       try {
-        if (isSpBlocked(this.configService.get("spBlocklists"), spAddress, logContext.providerId)) {
-          this.logger.log({
-            ...logContext,
-            event: "retrieval_job_blocked",
-            message: "Retrieval job skipped: provider is blocked for scheduled retrieval checks",
-          });
-          return "success";
-        }
         await this.retrievalService.performRandomRetrievalForProvider(spAddress, abortController.signal, logContext);
         return "success";
       } catch (error) {
@@ -728,16 +753,14 @@ export class JobsService implements OnModuleInit, OnApplicationShutdown {
     }, timeoutMs);
 
     await this.recordJobExecution("data_set_creation", async () => {
-      const dataSetLogContext = await this.resolveProviderJobContext(spAddress, job.id);
+      const dataSetLogContext = await this.resolveRunnableProviderJobContext(
+        "data_set_creation",
+        spAddress,
+        job.id,
+        "Data set creation job skipped: provider is blocked for scheduled data-storage checks",
+      );
+      if (dataSetLogContext == null) return "success";
       try {
-        if (isSpBlocked(this.configService.get("spBlocklists"), spAddress, dataSetLogContext.providerId)) {
-          this.logger.log({
-            ...dataSetLogContext,
-            event: "data_set_creation_job_blocked",
-            message: "Data set creation job skipped: provider is blocked for scheduled data-storage checks",
-          });
-          return "success";
-        }
         await provisionNextMissingDataSet(
           { dealService: this.dealService, logger: this.logger },
           spAddress,


### PR DESCRIPTION
## Summary
- centralize runtime SP blocklist handling in JobsService
- skip address-blocked jobs before resolving provider metadata
- keep ID-based blocking after provider context resolution
- add regression coverage for address-blocked queued jobs with missing provider context

## Verification
- pnpm -C apps/backend test src/jobs/jobs.service.spec.ts src/common/sp-blocklist.spec.ts
- pnpm -C apps/backend typecheck
- pnpm -C apps/backend check:ci

PR is on top of #452