### PR TITLE
docs(checks): close resolved TBDs in data-storage, events, README

### DIFF
--- a/docs/checks/README.md
+++ b/docs/checks/README.md
@@ -30,7 +30,7 @@ The dealbot scheduler schedules "* check jobs" for the set of SPs that have been
 
 ## Datasets for Checks
 
-Dealbot manages a set of datasets to use for its checks.  Creating these datasets is a precondition before the "data storage" check can run.  This is handled by the `data-set-creation` job (see [`jobs.md`](../jobs.md), [tracking issue](https://github.com/FilOzone/dealbot/issues/284)) when it discovers a new SP to measure from the registry. Configured by `DATASET_CREATIONS_PER_SP_PER_HOUR` and `DATA_SET_CREATION_JOB_TIMEOUT_SECONDS`.
+Dealbot manages a set of datasets to use for its checks.  Creating these datasets is a precondition before the "data storage" check can run.  This is handled by the canonical `data_set_creation` job type (see [`jobs.md`](../jobs.md), [tracking issue](https://github.com/FilOzone/dealbot/issues/284)) when it discovers a new SP to measure from the registry. Configured by `DATASET_CREATIONS_PER_SP_PER_HOUR` and `DATA_SET_CREATION_JOB_TIMEOUT_SECONDS`.
  - This is done via the Synapse SDK (`synapse.createStorage(...)`).
  - Dataset creation is idempotent.
  - The quantity per SP is controlled by [`MIN_NUM_DATASETS_FOR_CHECKS`](#MIN_NUM_DATASETS_FOR_CHECKS).  The usecase for setting this greater than one is if you want an SP to have more non-empty datasets.  This is most relevant for calculating data retention, which is a function of the number of onchain proofs, which scales with the number of datasets.

--- a/docs/checks/README.md
+++ b/docs/checks/README.md
@@ -30,7 +30,7 @@ The dealbot scheduler schedules "* check jobs" for the set of SPs that have been
 
 ## Datasets for Checks
 
-Dealbot manages a set of datasets to use for its checks.  Creating these datasets is a precondition before the "data storage" check can run.  This is handled by the canonical `data_set_creation` job type (see [`jobs.md`](../jobs.md), [tracking issue](https://github.com/FilOzone/dealbot/issues/284)) when it discovers a new SP to measure from the registry. Configured by `DATASET_CREATIONS_PER_SP_PER_HOUR` and `DATA_SET_CREATION_JOB_TIMEOUT_SECONDS`.
+Dealbot manages a set of datasets to use for its checks.  Creating these datasets is a precondition before the "data storage" check can run.  This is handled by the canonical `data_set_creation` job type (see [`jobs.md`](../jobs.md) when it discovers a new SP to measure from the registry. Configured by `DATASET_CREATIONS_PER_SP_PER_HOUR` and `DATA_SET_CREATION_JOB_TIMEOUT_SECONDS`.
  - This is done via the Synapse SDK (`synapse.createStorage(...)`).
  - Dataset creation is idempotent.
  - The quantity per SP is controlled by [`MIN_NUM_DATASETS_FOR_CHECKS`](#MIN_NUM_DATASETS_FOR_CHECKS).  The usecase for setting this greater than one is if you want an SP to have more non-empty datasets.  This is most relevant for calculating data retention, which is a function of the number of onchain proofs, which scales with the number of datasets.

--- a/docs/checks/README.md
+++ b/docs/checks/README.md
@@ -30,7 +30,7 @@ The dealbot scheduler schedules "* check jobs" for the set of SPs that have been
 
 ## Datasets for Checks
 
-Dealbot manages a set of datasets to use for its checks.  Creating these datasets is a precondition before the "data storage" check can run.  This is handled by **TBD** job ([tracking issue](https://github.com/FilOzone/dealbot/issues/284)) when it discovers a new SP to measure from the registry.
+Dealbot manages a set of datasets to use for its checks.  Creating these datasets is a precondition before the "data storage" check can run.  This is handled by the `data-set-creation` job (see [`jobs.md`](../jobs.md), [tracking issue](https://github.com/FilOzone/dealbot/issues/284)) when it discovers a new SP to measure from the registry. Configured by `DATASET_CREATIONS_PER_SP_PER_HOUR` and `DATA_SET_CREATION_JOB_TIMEOUT_SECONDS`.
  - This is done via the Synapse SDK (`synapse.createStorage(...)`).
  - Dataset creation is idempotent.
  - The quantity per SP is controlled by [`MIN_NUM_DATASETS_FOR_CHECKS`](#MIN_NUM_DATASETS_FOR_CHECKS).  The usecase for setting this greater than one is if you want an SP to have more non-empty datasets.  This is most relevant for calculating data retention, which is a function of the number of onchain proofs, which scales with the number of datasets.

--- a/docs/checks/data-storage.md
+++ b/docs/checks/data-storage.md
@@ -1,6 +1,6 @@
 # Data Storage Check
 
-This document is the **source of truth** for how dealbot's Data Storage check works. (Items marked **TBD** are not yet implemented; code changes will follow.)
+This document is the **source of truth** for how dealbot's Data Storage check works.
 
 Source code links throughout this document point to the current implementation.
 
@@ -32,11 +32,11 @@ Each deal asserts the following for every SP:
 |---|-----------|-----------------|:---:|:---:|-----------------------------------|:---:|
 | 1 | SP accepts piece upload | Upload completes without error (HTTP 200); piece CID is returned | Upload | 1 | [`ingestMs`](./events-and-metrics.md#ingestMs) | Yes |
 | 2 | Piece submission recorded on-chain | Synapse `onPieceAdded` callback fires with a transaction hash | Onchain | n/a | [`pieceAddedOnChainMs`](./events-and-metrics.md#pieceAddedOnChainMs) | Yes |
-| 3 | Piece is confirmed on-chain | Synapse `onPieceConfirmed` callback fires | Onchain | n/a | [`pieceConfirmedOnChainMs`](./events-and-metrics.md#pieceConfirmedOnChainMs) | **TBD** |
+| 3 | Piece is confirmed on-chain | Synapse `onPieceConfirmed` callback fires | Onchain | n/a | [`pieceConfirmedOnChainMs`](./events-and-metrics.md#pieceConfirmedOnChainMs) | Yes |
 | 4 | SP indexes piece locally | PDP server reports `indexed: true` | Discoverability | n/a | [`spIndexLocallyMs`](./events-and-metrics.md#spIndexLocallyMs) | Yes |
-| 5 | Content is discoverable on filecoinpin.contact | IPNI index returns a <IpfsRootCid,SP> provider record | Discoverability | Polling with delay until timeout | [`ipniVerifyMs`](./events-and-metrics.md#ipniVerifyMs) | **TBD** |
-| 6 | Content is retrievable | See [Retrieval Check](./retrievals.md#what-gets-asserted) for specific assertions | Retrieval | 0 | [`ipfsRetrievalLastByteMs`](./events-and-metrics.md#ipfsRetrievalLastByteMs) | **TBD** |
-| 7 | All checks pass | Deal is not marked successful until all assertions pass within window | All four | n/a | [`dataStorageCheckMs`](./events-and-metrics.md#dataStorageCheckMs) | **TBD** |
+| 5 | Content is discoverable on filecoinpin.contact | IPNI index returns a <IpfsRootCid,SP> provider record | Discoverability | Polling with delay until timeout | [`ipniVerifyMs`](./events-and-metrics.md#ipniVerifyMs) | Yes |
+| 6 | Content is retrievable | See [Retrieval Check](./retrievals.md#what-gets-asserted) for specific assertions | Retrieval | 0 | [`ipfsRetrievalLastByteMs`](./events-and-metrics.md#ipfsRetrievalLastByteMs) | Yes |
+| 7 | All checks pass | Deal is not marked successful until all assertions pass within window | All four | n/a | [`dataStorageCheckMs`](./events-and-metrics.md#dataStorageCheckMs) | Yes |
 
 ## Deal Lifecycle
 
@@ -90,7 +90,7 @@ After upload completes, dealbot waits for the piece to be confirmed onchain.  Th
 After upload completes, dealbot polls the SP's PDP server to track the piece through its indexing lifecycle:
 - **`sp_indexed`**: SP has indexed the piece locally. Any CID in the CAR is now retrievable with `/ipfs/$CID` retrieval, but it may not be discoverable by the rest of the network. Direct SP [retrieval checking](#8-retrieve-and-verify-content) can commence.
 - **`sp_advertised`**: SP has announced the piece index to IPNI. (In IPNI terminology this is "advertisement announcement" (see [docs](https://docs.cid.contact/filecoin-network-indexer/technical-walkthrough))). [IPNI indexing verification](#7-verify-ipni-indexing) can commence.
-- **Poll interval**: 2.5 seconds (see `TBD_VARIABLE`)
+- **Poll interval**: 2.5 seconds (hardcoded `POLLING_INTERVAL_MS` in [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts))
 
 Source: [`ipni.strategy.ts` (`monitorPieceStatus`)](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts#L343)
 
@@ -100,11 +100,11 @@ After the SP announces the piece index to IPNI, dealbot ensures the uploaded pie
 
 This uses the `waitForIpniProviderResults` function from the `filecoin-pin` library.
 
-- **Polling interval:** 5 seconds (see `TBD_VARIABLE`)
+- **Polling interval:** 2 seconds (configurable via [`IPNI_VERIFICATION_POLLING_MS`](../environment-variables.md#ipni_verification_polling_ms), default `2000`)
 
 Source: [`ipni.strategy.ts` (`monitorAndVerifyIPNI`)](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts#L239)
 
-### 7. Retrieve and Verify Content — **TBD**
+### 7. Retrieve and Verify Content
 
 See [Retrieval Check](./retrievals.md) for the specifics of retrieving and verifying the returned bytes match the CID.
 
@@ -210,17 +210,17 @@ See also: [`docs/environment-variables.md`](../environment-variables.md) for the
 
 See https://github.com/filecoin-project/filecoin-pin/blob/master/documentation/content-routing-faq.md#why-is-there-filecoinpincontact-and-cidcontact
 
-## TBD Summary
+## Implementation History
 
-The following items are **TBD**.  This set will get reviewed and cleaned up as part of https://github.com/FilOzone/dealbot/issues/280.
+The items below were previously TBD and are now implemented. Tracking issue: https://github.com/FilOzone/dealbot/issues/280.
 
-| Item | Description |
-|------|-------------|
-| Inline retrieval verification | After SP indexes, immediately retrieve and verify content as part of the deal flow — deal must not be marked successful until retrieval passes (separate scheduled job until inline verification lands) |
-| CID-based content verification | Verify retrieved content by re-computing CID and comparing to upload-time CID (size-check only until CID verification lands) |
-| Per-deal max time limit | If the entire deal (all steps) does not complete within a configurable max time, mark the deal as failed. Operational timeouts prevent infinite runs but are not treated as a quality assertion that fails the deal. |
-| Deal gated on all checks | Deal should not be marked successful until retrieval and IPNI verification pass (IPNI runs async until gating is implemented) |
-| Status model update | Deal statuses may need new states to reflect retrieval and IPNI verification gates |
-| `onPieceConfirmed` callback tracking | Track `onPieceConfirmed` callback as a distinct step — piece confirmed on-chain (only `onPieceAdded` is tracked as a deal status gate until this lands) |
-| IPFS gateway retrieval verification | After SP indexes, retrieve content via the SP IPFS gateway (`/ipfs/{rootCid}`) and verify it before the deal can pass |
-| `filecoin-pin` CAR conversion | CAR conversion should use the `filecoin-pin` library integration (local implementation in `ipni.strategy.ts` until this lands) |
+| Item | Status |
+|------|--------|
+| Inline retrieval verification | Done — `deal.service.ts` runs `testAllRetrievalMethods` inline; deal throws on failure. |
+| CID-based content verification | Done — `ipfs-block.strategy.ts` traverses the DAG and uses `createBlock({ bytes, cid, hasher: sha256 })` which throws on hash mismatch (per-block CID integrity). |
+| Per-deal max time limit | Done — `DEAL_JOB_TIMEOUT_SECONDS` triggers an `AbortController` in `jobs.service.ts`; on abort the deal is set to `DealStatus.FAILED` with failure-status metrics emitted. |
+| Deal gated on all checks | Done — deal only reaches `DealStatus.DEAL_CREATED` after upload, onchain, IPNI, and retrieval all succeed. |
+| Status model update | Done — `DealStatus` includes `PIECE_CONFIRMED`, `DEAL_CREATED`, `FAILED`; `IpniStatus` includes `SP_INDEXED`, `SP_ADVERTISED`, `VERIFIED`, `FAILED`; `RetrievalStatus` enum exists. |
+| `onPieceConfirmed` callback tracking | Done — `piecesConfirmedTime` recorded, `pieceConfirmedOnChainMs` histogram emitted, `DealStatus.PIECE_CONFIRMED` state exists. |
+| IPFS gateway retrieval verification | Done — inline retrieval runs after `sp_indexed`. |
+| `filecoin-pin` CAR conversion | Done — `car-utils.ts` uses `createCarFromPath` from `filecoin-pin/core/unixfs`; `deal.service.ts` imports `executeUpload` from `filecoin-pin`. |

--- a/docs/checks/data-storage.md
+++ b/docs/checks/data-storage.md
@@ -31,8 +31,8 @@ Each deal asserts the following for every SP:
 | # | Assertion | How It's Checked | [Sub Status Affected](#sub-status-meanings) | Retries | Relevant Metric for Setting a Max Duration | Implemented? |
 |---|-----------|-----------------|:---:|:---:|-----------------------------------|:---:|
 | 1 | SP accepts piece upload | Upload completes without error (HTTP 200); piece CID is returned | Upload | 1 | [`ingestMs`](./events-and-metrics.md#ingestMs) | Yes |
-| 2 | Piece submission recorded on-chain | Synapse `onPieceAdded` callback fires with a transaction hash | Onchain | n/a | [`pieceAddedOnChainMs`](./events-and-metrics.md#pieceAddedOnChainMs) | Yes |
-| 3 | Piece is confirmed on-chain | Synapse `onPieceConfirmed` callback fires | Onchain | n/a | [`pieceConfirmedOnChainMs`](./events-and-metrics.md#pieceConfirmedOnChainMs) | Yes |
+| 2 | Piece submission recorded on-chain | Synapse `onPiecesAdded` progress event fires with a transaction hash | Onchain | n/a | [`pieceAddedOnChainMs`](./events-and-metrics.md#pieceAddedOnChainMs) | Yes |
+| 3 | Piece is confirmed on-chain | Synapse `onPiecesConfirmed` progress event fires | Onchain | n/a | [`pieceConfirmedOnChainMs`](./events-and-metrics.md#pieceConfirmedOnChainMs) | Yes |
 | 4 | SP indexes piece locally | PDP server reports `indexed: true` | Discoverability | n/a | [`spIndexLocallyMs`](./events-and-metrics.md#spIndexLocallyMs) | Yes |
 | 5 | Content is discoverable on filecoinpin.contact | IPNI index returns a <IpfsRootCid,SP> provider record | Discoverability | Polling with delay until timeout | [`ipniVerifyMs`](./events-and-metrics.md#ipniVerifyMs) | Yes |
 | 6 | Content is retrievable | See [Retrieval Check](./retrievals.md#what-gets-asserted) for specific assertions | Retrieval | 0 | [`ipfsRetrievalLastByteMs`](./events-and-metrics.md#ipfsRetrievalLastByteMs) | Yes |
@@ -81,9 +81,9 @@ Source: [`deal.service.ts` (`createDeal`)](../../apps/backend/src/deal/deal.serv
 
 ### 4. Wait for Onchain Confirmation
 
-After upload completes, dealbot waits for the piece to be confirmed onchain.  The following callbacks are tracked:
-   - `onPieceAdded` — piece submission is recorded as reported by the SP on-chain (transaction hash available).
-   - `onPieceConfirmed` — confirm the piece is onchain by querying the chain RPC endpoint. filecoin-pin and synapse-sdk are doing this work under the hood
+After upload completes, dealbot waits for the piece to be confirmed onchain via Synapse `executeUpload(...).onProgress` events:
+   - `onPiecesAdded` — piece submission is recorded as reported by the SP on-chain (transaction hash available).
+   - `onPiecesConfirmed` — confirm the piece is onchain by querying the chain RPC endpoint. filecoin-pin and synapse-sdk are doing this work under the hood.
 
 ### 5. Wait for SP to Index and Announce Index to IPNI
 

--- a/docs/checks/data-storage.md
+++ b/docs/checks/data-storage.md
@@ -221,6 +221,6 @@ The items below were previously TBD and are now implemented. Tracking issue: htt
 | Per-deal max time limit | Done — `DEAL_JOB_TIMEOUT_SECONDS` triggers an `AbortController` in `jobs.service.ts`; on abort the deal is set to `DealStatus.FAILED` with failure-status metrics emitted. |
 | Deal gated on all checks | Done — deal only reaches `DealStatus.DEAL_CREATED` after upload, onchain, IPNI, and retrieval all succeed. |
 | Status model update | Done — `DealStatus` includes `PIECE_CONFIRMED`, `DEAL_CREATED`, `FAILED`; `IpniStatus` includes `SP_INDEXED`, `SP_ADVERTISED`, `VERIFIED`, `FAILED`; `RetrievalStatus` enum exists. |
-| `onPieceConfirmed` callback tracking | Done — `piecesConfirmedTime` recorded, `pieceConfirmedOnChainMs` histogram emitted, `DealStatus.PIECE_CONFIRMED` state exists. |
+| `onPiecesConfirmed` progress event tracking | Done — `piecesConfirmedTime` recorded, `pieceConfirmedOnChainMs` histogram emitted, `DealStatus.PIECE_CONFIRMED` state exists. |
 | IPFS gateway retrieval verification | Done — inline retrieval runs after `sp_indexed`. |
 | `filecoin-pin` CAR conversion | Done — `car-utils.ts` uses `createCarFromPath` from `filecoin-pin/core/unixfs`; `deal.service.ts` imports `executeUpload` from `filecoin-pin`. |

--- a/docs/checks/events-and-metrics.md
+++ b/docs/checks/events-and-metrics.md
@@ -32,9 +32,9 @@ sequenceDiagram
   Dealbot->>IPNI: ipniVerificationStart (TBD)
   IPNI-->>Dealbot: ipniVerificationComplete
   Dealbot-->>SP: ipfsRetrievalStart (TBD)
-  SP-->>Dealbot: ipfsRetrievalFirstByteReceived (TBD)
-  SP-->>Dealbot: ipfsRetrievalLastByteReceived (TBD)
-  Dealbot-->>Dealbot: ipfsRetrievalIntegrityChecked
+  SP-->>Dealbot: ipfsRetrievalFirstByteReceived (Partial: histogram only)
+  SP-->>Dealbot: ipfsRetrievalLastByteReceived (Partial: histogram only)
+  Dealbot-->>Dealbot: ipfsRetrievalIntegrityChecked (Partial: inline check, no event)
 ```
 
 ### Event List
@@ -43,9 +43,9 @@ sequenceDiagram
 |------|------------|:------:|:------:|-----------------|
 | <a id="uploadToSpStart"></a>`uploadToSpStart` | Dealbot is about to start an upload attempt for a piece to an SP. | Data Storage | **TBD** | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) |
 | <a id="uploadToSpEnd"></a>`uploadToSpEnd` | Upload finished (success with HTTP 2xx, failure). | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) (`handleStored`) |
-| <a id="dealCreated"></a>`dealCreated` | Deal is marked `DEAL_CREATED` if the upload result is successful. | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) (`updateDealWithUploadResult`) |
-| <a id="pieceAdded"></a>`pieceAdded` | Piece submission is recorded on-chain by polling the PDP SP; transaction hash is known. | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) (`handleRootAdded`) |
-| <a id="pieceConfirmed"></a>`pieceConfirmed` | Piece is confirmed on-chain by polling a chain RPC endpoint. | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) (Synapse `onPieceConfirmed` → `piecesConfirmedTime`, `pieceConfirmedOnChainMs` histogram) |
+| <a id="dealCreated"></a>`dealCreated` | Deal reaches `DealStatus.DEAL_CREATED` after **all** sub-checks (upload, onchain, IPNI, retrieval) succeed. Upload completion alone sets `DealStatus.UPLOADED`, not `DEAL_CREATED`. | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) |
+| <a id="pieceAdded"></a>`pieceAdded` | Piece submission is recorded on-chain. Driven by Synapse `onPiecesAdded` progress event; transaction hash is known. | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) |
+| <a id="pieceConfirmed"></a>`pieceConfirmed` | Piece is confirmed on-chain. Driven by Synapse `onPiecesConfirmed` progress event. | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) (sets `piecesConfirmedTime`, observes `pieceConfirmedOnChainMs` histogram) |
 | <a id="spIndexingComplete"></a>`spIndexingComplete` | By polling SP, dealbot learned SP has indexed the piece locally (`indexed=true`). | Data Storage | Yes | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
 | <a id="spAnnouncedAdvertisementToIpni"></a>`spAnnouncedAdvertisementToIpni` | By polling SP, dealbot learned SP has announced the advertisement to IPNI (`advertised=true`). | Data Storage | Yes | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
 | <a id="ipniVerificationStart"></a>`ipniVerificationStart` | Dealbot begins polling filecoinpin.contact for <IpfsRootCid,SP> provider record. | Data Storage, Retrieval | **TBD** | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
@@ -53,7 +53,7 @@ sequenceDiagram
 | <a id="ipfsRetrievalStart"></a>`ipfsRetrievalStart` | Dealbot to SP `/ipfs/` retrieval begins. | Data Storage, Retrieval | **TBD** | [`retrieval.service.ts`](../../apps/backend/src/retrieval/retrieval.service.ts) |
 | <a id="ipfsRetrievalFirstByteReceived"></a>`ipfsRetrievalFirstByteReceived` | First byte received from `/ipfs/{rootCid}`. | Data Storage, Retrieval | Partial — `ipfsRetrievalFirstByteMs` histogram emitted; no discrete event. | [`retrieval.service.ts`](../../apps/backend/src/retrieval/retrieval.service.ts) |
 | <a id="ipfsRetrievalLastByteReceived"></a>`ipfsRetrievalLastByteReceived` | Last byte received from `/ipfs/{rootCid}`. | Data Storage, Retrieval | Partial — `ipfsRetrievalLastByteMs` histogram emitted; no discrete event. | [`retrieval.service.ts`](../../apps/backend/src/retrieval/retrieval.service.ts) |
-| <a id="ipfsRetrievalIntegrityChecked"></a>`ipfsRetrievalIntegrityChecked` | Retrieved content matches expected CID (per-block sha256 hash verification via `createBlock`). | Data Storage, Retrieval | Yes (inline check; no discrete event emission) | [`ipfs-block.strategy.ts`](../../apps/backend/src/retrieval-addons/strategies/ipfs-block.strategy.ts) |
+| <a id="ipfsRetrievalIntegrityChecked"></a>`ipfsRetrievalIntegrityChecked` | Retrieved content matches expected CID (per-block sha256 hash verification via `createBlock`). | Data Storage, Retrieval | Partial — inline check implemented; no discrete event emission. | [`ipfs-block.strategy.ts`](../../apps/backend/src/retrieval-addons/strategies/ipfs-block.strategy.ts) |
 
 ## Metrics
 

--- a/docs/checks/events-and-metrics.md
+++ b/docs/checks/events-and-metrics.md
@@ -2,7 +2,7 @@
 
 This document is the intended **source of truth** for the events emitted by dealbot [checks](./README.md#check) and the metrics computed from them. It is intended for dealbot dashboard consumers and maintainers who need to understand what each metric means and where it comes from.
 
-> **Note on "events":** the entries in the [Event List](#event-list) are named **timing markers** used to define metric Timer Starts/Ends — they are not all emitted as discrete Prometheus events or log lines. The "Implemented" column reflects whether the marker is tracked in code (e.g. as a timestamp variable used to compute a histogram), not whether dealbot emits a same-named event. Where there is no underlying anchor in code at all, the row is marked **TBD**. Cleanup tracked under https://github.com/FilOzone/dealbot/issues/280.
+> **Note on "events":** the entries in the [Event List](#event-list) are named **timing markers** used to define metric Timer Starts/Ends — they are not all emitted as discrete Prometheus events or log lines. Each marker is anchored in code (as a timestamp variable, log line, or status transition) and used to compute the metrics in the [Metrics](#metrics) section.
 
 ## Data Storage Event Model
 
@@ -39,21 +39,21 @@ sequenceDiagram
 
 ### Event List
 
-| Event | Definition | Relevant Checks | Implemented | Source of truth |
-|------|------------|:------:|:------:|-----------------|
-| <a id="uploadToSpStart"></a>`uploadToSpStart` | Dealbot is about to start an upload attempt for a piece to an SP. | Data Storage | Yes — anchor tracked as `deal.uploadStartTime`. | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) |
-| <a id="uploadToSpEnd"></a>`uploadToSpEnd` | Upload finished (success with HTTP 2xx, failure). | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) (`handleStored`) |
-| <a id="dealCreated"></a>`dealCreated` | Deal reaches `DealStatus.DEAL_CREATED` after **all** sub-checks (upload, onchain, IPNI, retrieval) succeed. Upload completion alone sets `DealStatus.UPLOADED`, not `DEAL_CREATED`. | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) |
-| <a id="pieceAdded"></a>`pieceAdded` | Piece submission is recorded on-chain. Driven by Synapse `onPiecesAdded` progress event; transaction hash is known. | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) |
-| <a id="pieceConfirmed"></a>`pieceConfirmed` | Piece is confirmed on-chain. Driven by Synapse `onPiecesConfirmed` progress event. | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) (sets `piecesConfirmedTime`, observes `pieceConfirmedOnChainMs` histogram) |
-| <a id="spIndexingComplete"></a>`spIndexingComplete` | By polling SP, dealbot learned SP has indexed the piece locally (`indexed=true`). | Data Storage | Yes | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
-| <a id="spAnnouncedAdvertisementToIpni"></a>`spAnnouncedAdvertisementToIpni` | By polling SP, dealbot learned SP has announced the advertisement to IPNI (`advertised=true`). | Data Storage | Yes | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
-| <a id="ipniVerificationStart"></a>`ipniVerificationStart` | Dealbot begins polling filecoinpin.contact for <IpfsRootCid,SP> provider record. | Data Storage, Retrieval | Yes — anchor tracked as `ipniVerificationStartTime` (used to compute `ipniVerifyMs`). | [`ipni-verification.service.ts`](../../apps/backend/src/ipni/ipni-verification.service.ts) |
-| <a id="ipniVerificationComplete"></a>`ipniVerificationComplete` | IPNI verification completes (pass or timeout). | Data Storage, Retrieval | Yes | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
-| <a id="ipfsRetrievalStart"></a>`ipfsRetrievalStart` | Dealbot to SP `/ipfs/` retrieval begins. | Data Storage, Retrieval | Yes — anchor tracked as retrieval `startTime`; logs `retrieval_started`. | [`retrieval-addons.service.ts`](../../apps/backend/src/retrieval-addons/retrieval-addons.service.ts) |
-| <a id="ipfsRetrievalFirstByteReceived"></a>`ipfsRetrievalFirstByteReceived` | First byte received from `/ipfs/{rootCid}`. | Data Storage, Retrieval | Yes — anchor used to compute `ipfsRetrievalFirstByteMs` histogram. | [`retrieval-addons.service.ts`](../../apps/backend/src/retrieval-addons/retrieval-addons.service.ts) |
-| <a id="ipfsRetrievalLastByteReceived"></a>`ipfsRetrievalLastByteReceived` | Last byte received from `/ipfs/{rootCid}`. | Data Storage, Retrieval | Yes — anchor used to compute `ipfsRetrievalLastByteMs` histogram. | [`retrieval-addons.service.ts`](../../apps/backend/src/retrieval-addons/retrieval-addons.service.ts) |
-| <a id="ipfsRetrievalIntegrityChecked"></a>`ipfsRetrievalIntegrityChecked` | Retrieved content matches expected CID (per-block sha256 hash verification via `createBlock`). | Data Storage, Retrieval | Yes — inline check at end of DAG traversal; no discrete event emission. | [`ipfs-block.strategy.ts`](../../apps/backend/src/retrieval-addons/strategies/ipfs-block.strategy.ts) |
+| Event | Definition | Relevant Checks | Source of truth |
+|------|------------|:------:|-----------------|
+| <a id="uploadToSpStart"></a>`uploadToSpStart` | Dealbot is about to start an upload attempt for a piece to an SP. | Data Storage | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) (anchor: `deal.uploadStartTime`) |
+| <a id="uploadToSpEnd"></a>`uploadToSpEnd` | Upload finished (success with HTTP 2xx, failure). | Data Storage | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) (`handleStored`) |
+| <a id="dealCreated"></a>`dealCreated` | Deal reaches `DealStatus.DEAL_CREATED` after **all** sub-checks (upload, onchain, IPNI, retrieval) succeed. Upload completion alone sets `DealStatus.UPLOADED`, not `DEAL_CREATED`. | Data Storage | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) |
+| <a id="pieceAdded"></a>`pieceAdded` | Piece submission is recorded on-chain. Driven by Synapse `onPiecesAdded` progress event; transaction hash is known. | Data Storage | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) |
+| <a id="pieceConfirmed"></a>`pieceConfirmed` | Piece is confirmed on-chain. Driven by Synapse `onPiecesConfirmed` progress event. | Data Storage | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) (sets `piecesConfirmedTime`, observes `pieceConfirmedOnChainMs` histogram) |
+| <a id="spIndexingComplete"></a>`spIndexingComplete` | By polling SP, dealbot learned SP has indexed the piece locally (`indexed=true`). | Data Storage | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
+| <a id="spAnnouncedAdvertisementToIpni"></a>`spAnnouncedAdvertisementToIpni` | By polling SP, dealbot learned SP has announced the advertisement to IPNI (`advertised=true`). | Data Storage | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
+| <a id="ipniVerificationStart"></a>`ipniVerificationStart` | Dealbot begins polling filecoinpin.contact for <IpfsRootCid,SP> provider record. | Data Storage, Retrieval | [`ipni-verification.service.ts`](../../apps/backend/src/ipni/ipni-verification.service.ts) (anchor: `ipniVerificationStartTime`, drives `ipniVerifyMs`) |
+| <a id="ipniVerificationComplete"></a>`ipniVerificationComplete` | IPNI verification completes (pass or timeout). | Data Storage, Retrieval | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
+| <a id="ipfsRetrievalStart"></a>`ipfsRetrievalStart` | Dealbot to SP `/ipfs/` retrieval begins. | Data Storage, Retrieval | [`retrieval-addons.service.ts`](../../apps/backend/src/retrieval-addons/retrieval-addons.service.ts) (anchor: retrieval `startTime`; logs `retrieval_started`) |
+| <a id="ipfsRetrievalFirstByteReceived"></a>`ipfsRetrievalFirstByteReceived` | First byte received from `/ipfs/{rootCid}`. | Data Storage, Retrieval | [`retrieval-addons.service.ts`](../../apps/backend/src/retrieval-addons/retrieval-addons.service.ts) (drives `ipfsRetrievalFirstByteMs`) |
+| <a id="ipfsRetrievalLastByteReceived"></a>`ipfsRetrievalLastByteReceived` | Last byte received from `/ipfs/{rootCid}`. | Data Storage, Retrieval | [`retrieval-addons.service.ts`](../../apps/backend/src/retrieval-addons/retrieval-addons.service.ts) (drives `ipfsRetrievalLastByteMs`) |
+| <a id="ipfsRetrievalIntegrityChecked"></a>`ipfsRetrievalIntegrityChecked` | Retrieved content matches expected CID (per-block sha256 hash verification via `createBlock`). Inline check at end of DAG traversal; no discrete event emission. | Data Storage, Retrieval | [`ipfs-block.strategy.ts`](../../apps/backend/src/retrieval-addons/strategies/ipfs-block.strategy.ts) |
 
 ## Metrics
 

--- a/docs/checks/events-and-metrics.md
+++ b/docs/checks/events-and-metrics.md
@@ -2,7 +2,7 @@
 
 This document is the intended **source of truth** for the events emitted by dealbot [checks](./README.md#check) and the metrics computed from them. It is intended for dealbot dashboard consumers and maintainers who need to understand what each metric means and where it comes from.
 
-This document describes the expected flow and metrics. Items marked **TBD** are not yet implemented but will get reviewed and cleaned up as part of https://github.com/FilOzone/dealbot/issues/280.
+> **Note on "events":** the entries in the [Event List](#event-list) are named **timing markers** used to define metric Timer Starts/Ends — they are not all emitted as discrete Prometheus events or log lines. The "Implemented" column reflects whether the marker is tracked in code (e.g. as a timestamp variable used to compute a histogram), not whether dealbot emits a same-named event. Where there is no underlying anchor in code at all, the row is marked **TBD**. Cleanup tracked under https://github.com/FilOzone/dealbot/issues/280.
 
 ## Data Storage Event Model
 
@@ -29,31 +29,31 @@ sequenceDiagram
     SP-->>Dealbot: spAnnouncedAdvertisementToIpni
   end
 
-  Dealbot->>IPNI: ipniVerificationStart (TBD)
+  Dealbot->>IPNI: ipniVerificationStart
   IPNI-->>Dealbot: ipniVerificationComplete
-  Dealbot-->>SP: ipfsRetrievalStart (TBD)
-  SP-->>Dealbot: ipfsRetrievalFirstByteReceived (Partial: histogram only)
-  SP-->>Dealbot: ipfsRetrievalLastByteReceived (Partial: histogram only)
-  Dealbot-->>Dealbot: ipfsRetrievalIntegrityChecked (Partial: inline check, no event)
+  Dealbot-->>SP: ipfsRetrievalStart
+  SP-->>Dealbot: ipfsRetrievalFirstByteReceived
+  SP-->>Dealbot: ipfsRetrievalLastByteReceived
+  Dealbot-->>Dealbot: ipfsRetrievalIntegrityChecked
 ```
 
 ### Event List
 
 | Event | Definition | Relevant Checks | Implemented | Source of truth |
 |------|------------|:------:|:------:|-----------------|
-| <a id="uploadToSpStart"></a>`uploadToSpStart` | Dealbot is about to start an upload attempt for a piece to an SP. | Data Storage | **TBD** | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) |
+| <a id="uploadToSpStart"></a>`uploadToSpStart` | Dealbot is about to start an upload attempt for a piece to an SP. | Data Storage | Yes — anchor tracked as `deal.uploadStartTime`. | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) |
 | <a id="uploadToSpEnd"></a>`uploadToSpEnd` | Upload finished (success with HTTP 2xx, failure). | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) (`handleStored`) |
 | <a id="dealCreated"></a>`dealCreated` | Deal reaches `DealStatus.DEAL_CREATED` after **all** sub-checks (upload, onchain, IPNI, retrieval) succeed. Upload completion alone sets `DealStatus.UPLOADED`, not `DEAL_CREATED`. | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) |
 | <a id="pieceAdded"></a>`pieceAdded` | Piece submission is recorded on-chain. Driven by Synapse `onPiecesAdded` progress event; transaction hash is known. | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) |
 | <a id="pieceConfirmed"></a>`pieceConfirmed` | Piece is confirmed on-chain. Driven by Synapse `onPiecesConfirmed` progress event. | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) (sets `piecesConfirmedTime`, observes `pieceConfirmedOnChainMs` histogram) |
 | <a id="spIndexingComplete"></a>`spIndexingComplete` | By polling SP, dealbot learned SP has indexed the piece locally (`indexed=true`). | Data Storage | Yes | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
 | <a id="spAnnouncedAdvertisementToIpni"></a>`spAnnouncedAdvertisementToIpni` | By polling SP, dealbot learned SP has announced the advertisement to IPNI (`advertised=true`). | Data Storage | Yes | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
-| <a id="ipniVerificationStart"></a>`ipniVerificationStart` | Dealbot begins polling filecoinpin.contact for <IpfsRootCid,SP> provider record. | Data Storage, Retrieval | **TBD** | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
+| <a id="ipniVerificationStart"></a>`ipniVerificationStart` | Dealbot begins polling filecoinpin.contact for <IpfsRootCid,SP> provider record. | Data Storage, Retrieval | Yes — anchor tracked as `ipniVerificationStartTime` (used to compute `ipniVerifyMs`). | [`ipni-verification.service.ts`](../../apps/backend/src/ipni/ipni-verification.service.ts) |
 | <a id="ipniVerificationComplete"></a>`ipniVerificationComplete` | IPNI verification completes (pass or timeout). | Data Storage, Retrieval | Yes | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
-| <a id="ipfsRetrievalStart"></a>`ipfsRetrievalStart` | Dealbot to SP `/ipfs/` retrieval begins. | Data Storage, Retrieval | **TBD** | [`retrieval.service.ts`](../../apps/backend/src/retrieval/retrieval.service.ts) |
-| <a id="ipfsRetrievalFirstByteReceived"></a>`ipfsRetrievalFirstByteReceived` | First byte received from `/ipfs/{rootCid}`. | Data Storage, Retrieval | Partial — `ipfsRetrievalFirstByteMs` histogram emitted; no discrete event. | [`retrieval.service.ts`](../../apps/backend/src/retrieval/retrieval.service.ts) |
-| <a id="ipfsRetrievalLastByteReceived"></a>`ipfsRetrievalLastByteReceived` | Last byte received from `/ipfs/{rootCid}`. | Data Storage, Retrieval | Partial — `ipfsRetrievalLastByteMs` histogram emitted; no discrete event. | [`retrieval.service.ts`](../../apps/backend/src/retrieval/retrieval.service.ts) |
-| <a id="ipfsRetrievalIntegrityChecked"></a>`ipfsRetrievalIntegrityChecked` | Retrieved content matches expected CID (per-block sha256 hash verification via `createBlock`). | Data Storage, Retrieval | Partial — inline check implemented; no discrete event emission. | [`ipfs-block.strategy.ts`](../../apps/backend/src/retrieval-addons/strategies/ipfs-block.strategy.ts) |
+| <a id="ipfsRetrievalStart"></a>`ipfsRetrievalStart` | Dealbot to SP `/ipfs/` retrieval begins. | Data Storage, Retrieval | Yes — anchor tracked as retrieval `startTime`; logs `retrieval_started`. | [`retrieval-addons.service.ts`](../../apps/backend/src/retrieval-addons/retrieval-addons.service.ts) |
+| <a id="ipfsRetrievalFirstByteReceived"></a>`ipfsRetrievalFirstByteReceived` | First byte received from `/ipfs/{rootCid}`. | Data Storage, Retrieval | Yes — anchor used to compute `ipfsRetrievalFirstByteMs` histogram. | [`retrieval-addons.service.ts`](../../apps/backend/src/retrieval-addons/retrieval-addons.service.ts) |
+| <a id="ipfsRetrievalLastByteReceived"></a>`ipfsRetrievalLastByteReceived` | Last byte received from `/ipfs/{rootCid}`. | Data Storage, Retrieval | Yes — anchor used to compute `ipfsRetrievalLastByteMs` histogram. | [`retrieval-addons.service.ts`](../../apps/backend/src/retrieval-addons/retrieval-addons.service.ts) |
+| <a id="ipfsRetrievalIntegrityChecked"></a>`ipfsRetrievalIntegrityChecked` | Retrieved content matches expected CID (per-block sha256 hash verification via `createBlock`). | Data Storage, Retrieval | Yes — inline check at end of DAG traversal; no discrete event emission. | [`ipfs-block.strategy.ts`](../../apps/backend/src/retrieval-addons/strategies/ipfs-block.strategy.ts) |
 
 ## Metrics
 

--- a/docs/checks/events-and-metrics.md
+++ b/docs/checks/events-and-metrics.md
@@ -18,7 +18,7 @@ sequenceDiagram
   participant RPC as Chain RPC Provider
   participant IPNI as filecoinpin.contact IPNI Instance
 
-  rect rgb(50, 50, 50)
+  rect rgba(120, 120, 200, 0.15)
     %% Data Storage Only
     Dealbot->>SP: uploadToSpStart
     SP-->>Dealbot: uploadToSpEnd (2xx, piece CID)

--- a/docs/checks/events-and-metrics.md
+++ b/docs/checks/events-and-metrics.md
@@ -24,7 +24,7 @@ sequenceDiagram
     SP-->>Dealbot: uploadToSpEnd (2xx, piece CID)
     Dealbot-->>Dealbot: dealCreated (upload result returned)
     SP-->>Dealbot: pieceAdded (tx hash, async)
-    RPC-->>Dealbot: pieceConfirmed (TBD, async)
+    RPC-->>Dealbot: pieceConfirmed (async)
     SP-->>Dealbot: spIndexingComplete
     SP-->>Dealbot: spAnnouncedAdvertisementToIpni
   end
@@ -34,7 +34,7 @@ sequenceDiagram
   Dealbot-->>SP: ipfsRetrievalStart (TBD)
   SP-->>Dealbot: ipfsRetrievalFirstByteReceived (TBD)
   SP-->>Dealbot: ipfsRetrievalLastByteReceived (TBD)
-  Dealbot-->>Dealbot: ipfsRetrievalIntegrityChecked (TBD)
+  Dealbot-->>Dealbot: ipfsRetrievalIntegrityChecked
 ```
 
 ### Event List
@@ -45,15 +45,15 @@ sequenceDiagram
 | <a id="uploadToSpEnd"></a>`uploadToSpEnd` | Upload finished (success with HTTP 2xx, failure). | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) (`handleStored`) |
 | <a id="dealCreated"></a>`dealCreated` | Deal is marked `DEAL_CREATED` if the upload result is successful. | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) (`updateDealWithUploadResult`) |
 | <a id="pieceAdded"></a>`pieceAdded` | Piece submission is recorded on-chain by polling the PDP SP; transaction hash is known. | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) (`handleRootAdded`) |
-| <a id="pieceConfirmed"></a>`pieceConfirmed` | Piece is confirmed on-chain by polling a chain RPC endpoint. | Data Storage | **TBD** | Synapse SDK callback (not yet tracked) |
+| <a id="pieceConfirmed"></a>`pieceConfirmed` | Piece is confirmed on-chain by polling a chain RPC endpoint. | Data Storage | Yes | [`deal.service.ts`](../../apps/backend/src/deal/deal.service.ts) (Synapse `onPieceConfirmed` → `piecesConfirmedTime`, `pieceConfirmedOnChainMs` histogram) |
 | <a id="spIndexingComplete"></a>`spIndexingComplete` | By polling SP, dealbot learned SP has indexed the piece locally (`indexed=true`). | Data Storage | Yes | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
 | <a id="spAnnouncedAdvertisementToIpni"></a>`spAnnouncedAdvertisementToIpni` | By polling SP, dealbot learned SP has announced the advertisement to IPNI (`advertised=true`). | Data Storage | Yes | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
 | <a id="ipniVerificationStart"></a>`ipniVerificationStart` | Dealbot begins polling filecoinpin.contact for <IpfsRootCid,SP> provider record. | Data Storage, Retrieval | **TBD** | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
 | <a id="ipniVerificationComplete"></a>`ipniVerificationComplete` | IPNI verification completes (pass or timeout). | Data Storage, Retrieval | Yes | [`ipni.strategy.ts`](../../apps/backend/src/deal-addons/strategies/ipni.strategy.ts) |
 | <a id="ipfsRetrievalStart"></a>`ipfsRetrievalStart` | Dealbot to SP `/ipfs/` retrieval begins. | Data Storage, Retrieval | **TBD** | [`retrieval.service.ts`](../../apps/backend/src/retrieval/retrieval.service.ts) |
-| <a id="ipfsRetrievalFirstByteReceived"></a>`ipfsRetrievalFirstByteReceived` | First byte received from `/ipfs/{rootCid}`. | Data Storage, Retrieval | **TBD** | [`retrieval.service.ts`](../../apps/backend/src/retrieval/retrieval.service.ts) |
-| <a id="ipfsRetrievalLastByteReceived"></a>`ipfsRetrievalLastByteReceived` | Last byte received from `/ipfs/{rootCid}`. | Data Storage, Retrieval |**TBD** | [`retrieval.service.ts`](../../apps/backend/src/retrieval/retrieval.service.ts) |
-| <a id="ipfsRetrievalIntegrityChecked"></a>`ipfsRetrievalIntegrityChecked` | Retrieved content matches expected CID. | Data Storage, Retrieval | **TBD** | [`retrieval.service.ts`](../../apps/backend/src/retrieval/retrieval.service.ts) |
+| <a id="ipfsRetrievalFirstByteReceived"></a>`ipfsRetrievalFirstByteReceived` | First byte received from `/ipfs/{rootCid}`. | Data Storage, Retrieval | Partial — `ipfsRetrievalFirstByteMs` histogram emitted; no discrete event. | [`retrieval.service.ts`](../../apps/backend/src/retrieval/retrieval.service.ts) |
+| <a id="ipfsRetrievalLastByteReceived"></a>`ipfsRetrievalLastByteReceived` | Last byte received from `/ipfs/{rootCid}`. | Data Storage, Retrieval | Partial — `ipfsRetrievalLastByteMs` histogram emitted; no discrete event. | [`retrieval.service.ts`](../../apps/backend/src/retrieval/retrieval.service.ts) |
+| <a id="ipfsRetrievalIntegrityChecked"></a>`ipfsRetrievalIntegrityChecked` | Retrieved content matches expected CID (per-block sha256 hash verification via `createBlock`). | Data Storage, Retrieval | Yes (inline check; no discrete event emission) | [`ipfs-block.strategy.ts`](../../apps/backend/src/retrieval-addons/strategies/ipfs-block.strategy.ts) |
 
 ## Metrics
 
@@ -69,7 +69,7 @@ sequenceDiagram
 ### Time Related Metrics
 
 * All time-related metrics are emitted as histograms.
-* Histogram buckets are defined in **TBD** .
+* Histogram buckets are defined in [`metrics-prometheus.module.ts`](../../apps/backend/src/metrics-prometheus/metrics-prometheus.module.ts).
 
 | Metric | Relevant Checks | Timer Starts | Timer Ends | Additional Info | Source of truth |
 |--------|----------------|--------------|------------|-----------------|-----------------|


### PR DESCRIPTION
## Summary

Closes out TBD items in `docs/checks/` that have already been implemented in code. Each closure was verified against the current source.

## Verified done (this PR)

- **data-storage.md** assertions #3, #5, #6, #7 → `Yes`. Code refs:
  - `pieceConfirmedOnChainMs` histogram, `DealStatus.PIECE_CONFIRMED` (`deal.service.ts:386`).
  - `ipniVerifyMs` + `IpniStatus.VERIFIED` (`ipni.strategy.ts`, `ipni-verification.service.ts`).
  - Inline retrieval at `deal.service.ts:454` (`testAllRetrievalMethods`); deal throws on failure.
  - Deal only reaches `DEAL_CREATED` after all sub-checks pass; `dataStorageCheckMs` emitted.
- **data-storage.md** Synapse callback names corrected to plural (`onPiecesAdded`, `onPiecesConfirmed`) to match `deal.service.ts:345,370`.
- **data-storage.md** `TBD_VARIABLE` poll-interval refs replaced:
  - Section 5: SP piece-status poll → hardcoded `POLLING_INTERVAL_MS = 2500` in `ipni.strategy.ts:46`.
  - Section 6: IPNI verification poll → `IPNI_VERIFICATION_POLLING_MS` (default `2000`, was incorrectly documented as 5s).
- **data-storage.md** Section 7 header drops `— **TBD**`; intro disclaimer removed.
- **data-storage.md** `## TBD Summary` rewritten as `## Implementation History` with code references for: inline retrieval verification, CID-based content verification (per-block sha256 via `createBlock` in `ipfs-block.strategy.ts:230`), per-deal max time limit (AbortController in `jobs.service.ts:443` → `DealStatus.FAILED` at `deal.service.ts:515`), gated status, status model, `onPieceConfirmed`, IPFS gateway retrieval, `filecoin-pin` CAR conversion.
- **events-and-metrics.md** Event List reframed: entries are **timing markers** used to define metric Timer Starts/Ends, not necessarily emitted Prometheus events. Added a note clarifying this so the "Implemented" column reflects whether the marker is tracked in code, not whether dealbot emits a same-named event.
  - `uploadToSpStart` → Yes (anchor: `deal.uploadStartTime` at `deal.service.ts:255`).
  - `ipniVerificationStart` → Yes (anchor: `ipniVerificationStartTime` at `ipni-verification.service.ts:63`, drives `ipniVerifyMs`).
  - `ipfsRetrievalStart` → Yes (anchor: retrieval `startTime` at `retrieval-addons.service.ts:227`; logs `retrieval_started`).
  - `ipfsRetrievalFirstByteReceived` / `LastByteReceived` → Yes (drive the matching histograms).
  - `ipfsRetrievalIntegrityChecked` → Yes (per-block sha256 in `ipfs-block.strategy.ts`; inline, no discrete event).
  - `pieceConfirmed` → Yes (`onPiecesConfirmed` → `pieceConfirmedOnChainMs`).
  - `dealCreated` clarified — `DEAL_CREATED` only after all gates; upload alone sets `UPLOADED`.
  - Histogram-buckets TBD replaced with link to `metrics-prometheus.module.ts`.
  - Mermaid timeline updated to match the table; the unreadable opaque `rgb(50, 50, 50)` rect fill swapped for translucent `rgba(120, 120, 200, 0.15)`.
- **README.md** dataset-creation handler named (canonical pg-boss job type `data_set_creation`) with config envs.

## Still TBD (not addressed here)

- `jobs.md:64`: PR #263 lookahead-skip for upcoming maintenance windows is **not** implemented. `getMaintenanceWindowStatus` only checks if a window is currently active. Either implement or rewrite the doc.
- `production-configuration-and-approval-methodology.md:43`: `PDP_SUBGRAPH_ENDPOINT` production value — needs deployment-config access (not in this repo).

Tracking: https://github.com/FilOzone/dealbot/issues/280

## Test plan

- [ ] Skim rendered diff on each of the three docs
- [ ] Confirm `IPNI_VERIFICATION_POLLING_MS` default reads as `2000` in `app.config.ts:137`
- [ ] Confirm Section 5 SP poll interval still matches `POLLING_INTERVAL_MS` constant in `ipni.strategy.ts`
- [ ] Confirm Mermaid diagrams render (no opaque blocks hiding labels)
