### PR TITLE
chore: add Copilot PR review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,8 +16,8 @@ Review for material correctness, security, state-consistency, compatibility, or 
 ## Dealbot Context
 
 - TypeScript monorepo: NestJS backend (`apps/backend`), React/Vite frontend (`apps/web`), subgraph (`apps/subgraph`).
-- Postgres is the source of truth for operational state.
-- ClickHouse stores telemetry events. The cluster, schema, and migrations are owned by an external team. Review ClickHouse-touching code for dealbot impact (event payload shape, producer-side correctness, regressions to dealbot operations); do not propose ClickHouse schema, retention, or operational tuning changes.
+- Sources of truth: Postgres (operational state) and Prometheus (metrics). Discourage adding new persisted DB state; prefer events/metrics or reusing existing columns. Flag PRs that store data the system does not need.
+- ClickHouse: the DDL (`apps/backend/src/clickhouse/clickhouse.schema.ts`) and event payloads are owned in-repo and in-scope for review (schema, column types, payload shape, producer correctness). Cluster ops, retention, and infra tuning are owned by an external team — do not propose changes there.
 - A "check" is a task type (data storage, retrieval, data retention). A "job" is one execution of a check against one SP.
 
 ## Core Invariants
@@ -41,7 +41,6 @@ Review for material correctness, security, state-consistency, compatibility, or 
 - Tests, mocks, or fixtures that no longer match the real runtime or API contract.
 - SQL issues involving quoted identifiers, nullability, conflict keys, cross-network collisions, or behavior differences between databases.
 - Error handling or observability gaps that would make failures hard to diagnose, mitigate, or roll back.
-- Performance or resource issues likely to matter in normal production use, not hypothetical micro-optimizations.
 
 ## Repository-Specific Focus
 
@@ -58,7 +57,7 @@ Review for material correctness, security, state-consistency, compatibility, or 
 
 Use one issue per comment:
 
-- `Severity: short title`
+- `Blocker: short title` or `Important: short title`
 - what is wrong and where it appears
 - why it matters
 - minimal fix or concrete next step

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,64 @@
+# Pull Request Review Instructions
+
+## Goal
+
+Review for material correctness, security, state-consistency, compatibility, or maintainability regressions. Optimize for high-signal feedback. Prefer silence over speculation.
+
+## Review Philosophy
+
+- Comment only when confident a real issue exists in the changed code or its immediate context.
+- Prioritize issues as `Blocker` or `Important`.
+- Prefer incremental improvement over idealized rewrites. Do not request broad refactors unless needed to prevent a defect.
+- Focus on issues the author can reasonably address in this PR.
+- If the PR is too large to review confidently, leave at most one comment asking for a smaller PR.
+- If uncertain, do not comment.
+
+## Dealbot Context
+
+- TypeScript monorepo: NestJS backend (`apps/backend`), React/Vite frontend (`apps/web`), subgraph (`apps/subgraph`).
+- Postgres is the source of truth for operational state.
+- ClickHouse stores telemetry events. The cluster, schema, and migrations are owned by an external team. Review ClickHouse-touching code for dealbot impact (event payload shape, producer-side correctness, regressions to dealbot operations); do not propose ClickHouse schema, retention, or operational tuning changes.
+- A "check" is a task type (data storage, retrieval, data retention). A "job" is one execution of a check against one SP.
+
+## Core Invariants
+
+- At most one job per SP per check type per network runs at a time. Flag changes that could allow concurrent or duplicate jobs for the same SP on the same network.
+- A job is marked failed only when job execution itself fails. A check that completes and reports a negative outcome is a successful job with a failing check result. Do not treat a negative check result as a job failure.
+- Scheduling, cleanup, active-provider filtering, and queue execution must agree on the same set of SPs and the same network.
+- For network-aware code, inserts, queries, conflict keys, filters, and tests must all carry the same network invariants.
+
+## Priorities
+
+### Blocker
+
+- Security vulnerabilities, secrets exposure, broken auth/authz, unsafe input handling, or logs that could leak tokens, credentials, or private data.
+- Correctness defects that break job lifecycle invariants, provider filtering, multi-network behavior, retries, queue execution, or state transitions.
+- Breaking schema, migration, query, config, or storage changes without compatibility, rollout, or migration safety.
+- Missing validation, permission checks, or failure handling where users, data, or production stability could be harmed.
+
+### Important
+
+- Tests, mocks, or fixtures that no longer match the real runtime or API contract.
+- SQL issues involving quoted identifiers, nullability, conflict keys, cross-network collisions, or behavior differences between databases.
+- Error handling or observability gaps that would make failures hard to diagnose, mitigate, or roll back.
+- Performance or resource issues likely to matter in normal production use, not hypothetical micro-optimizations.
+
+## Repository-Specific Focus
+
+- When changing provider filtering or blocklists, look for stale schedules, skipped cleanup, duplicate work, or drift between selection and execution paths.
+- For frontend changes, prioritize user-visible correctness and contract drift over low-impact optimizations.
+
+## Do Not Comment On
+
+- Formatting, lint, import order, generated files, lockfiles, or issues already enforced by CI, formatters, or static analysis (unless the issue reflects a real runtime bug or missing invariant).
+- Pure preference between multiple reasonable approaches.
+- Minor naming tweaks, comment additions, or speculative future refactors unless they hide a real defect or maintenance risk.
+
+## Comment Format
+
+Use one issue per comment:
+
+- `Severity: short title`
+- what is wrong and where it appears
+- why it matters
+- minimal fix or concrete next step


### PR DESCRIPTION
## Summary

Adds `.github/copilot-instructions.md` to guide GitHub Copilot's PR review toward high-signal, dealbot-specific feedback and away from CI-duplicate noise.

## Process

- **Platform research**: reviewed Copilot's review constraints (4000-char base-branch read, Comment-only review, no merge gating, no external link following) plus Google/Microsoft/OWASP/NIST review literature.
- **Empirical analysis**: analyzed 319 Copilot inline comments across the last 150 dealbot PRs. Identified where Copilot reviews well (job-state consistency, test/fixture-contract drift, multi-network behavior, quoted SQL identifiers, redaction — PRs #452, #463, #471, #472, #453) versus where it overreaches (generic-SQL assumptions on ClickHouse code — PRs #438, #485; low-priority frontend optimization comments).
- **Adversarial iteration**: ran self-review against the evidence, then a second-opinion review (Codex) to tighten wording, fit the 4000-byte budget, and encode dealbot-specific invariants. Three diff rounds.

## What's encoded

- **Context**: monorepo layout, Postgres = source of truth, ClickHouse cluster/schema/migrations owned by external team — review CH-touching code for dealbot impact (payload shape, producer correctness, ops regressions); skip CH schema/retention/ops design suggestions.
- **Core invariants**:
  - at most one job per SP per check type per network at a time
  - jobs fail only on execution failure, not on negative check results
  - scheduling, cleanup, active-provider filtering, and queue execution agree on the same SP set and network
  - network-aware code carries the same network invariants across inserts, queries, conflict keys, filters, and tests
- **Blocker / Important** priorities aligned to observed high-value themes.
- **Do Not Comment On** list to suppress noise already covered by CI (Biome, build, typecheck, test, Docker, conventional-commit PR titles).

Final size: **3890 / 4000 bytes** (~110 byte headroom).

## Notes for reviewers

- Copilot reads custom instructions from the **base branch**, so this PR will not exercise its own instructions. Land first; evaluate on subsequent PRs.
- Comments that drove specific lines:
  - CH ownership wording: PRs #438, #485
  - Network invariants and "per network" precision: PR #463
  - Provider blocklist drift (selection vs execution): PR #452
  - Quoted Postgres identifier / `NULL NOT IN` semantics: PR #471
  - Frontend UX vs low-impact optimization framing: PR #472
  - Token redaction / logging: PR #453

## Test plan

- [ ] Confirm file is under 4000 bytes (`wc -c .github/copilot-instructions.md`)
- [ ] After merge, observe Copilot review behavior on the next 5–10 PRs
- [ ] Track whether CI-duplicate noise drops and whether ClickHouse generic-SQL false positives stop appearing
- [ ] Iterate (add path-specific `.github/instructions/*.instructions.md` overlays only if repeated patterns emerge)