### PR TITLE
fix(ipni): preserve failure reason in deal-flow rethrow

### DIFF
--- a/apps/backend/src/deal-addons/strategies/ipni.strategy.ts
+++ b/apps/backend/src/deal-addons/strategies/ipni.strategy.ts
@@ -245,8 +245,11 @@ export class IpniAddonStrategy implements IDealAddon<IpniMetadata> {
       signal?.throwIfAborted();
 
       if (!result.ipniResult.rootCIDVerified) {
-        const reason = result.ipniResult.failedCIDs[0]?.reason ?? "root CID not verified";
-        throw new Error(`IPNI verification failed for deal ${deal.id}: ${reason}`);
+        const reason = result.ipniResult.failedCIDs[0]?.reason;
+        throw new Error(
+          `IPNI verification failed for deal ${deal.id}: root CID not verified`,
+          reason ? { cause: new Error(reason) } : undefined,
+        );
       }
     } catch (error) {
       signal?.throwIfAborted();

--- a/apps/backend/src/deal-addons/strategies/ipni.strategy.ts
+++ b/apps/backend/src/deal-addons/strategies/ipni.strategy.ts
@@ -245,7 +245,8 @@ export class IpniAddonStrategy implements IDealAddon<IpniMetadata> {
       signal?.throwIfAborted();
 
       if (!result.ipniResult.rootCIDVerified) {
-        throw new Error(`IPNI verification failed for deal ${deal.id}: root CID not verified`);
+        const reason = result.ipniResult.failedCIDs[0]?.reason ?? "root CID not verified";
+        throw new Error(`IPNI verification failed for deal ${deal.id}: ${reason}`);
       }
     } catch (error) {
       signal?.throwIfAborted();


### PR DESCRIPTION
## Summary

- Closes #473
- One-line change: pass `ipniResult.failedCIDs[0].reason` through to the rethrow at `apps/backend/src/deal-addons/strategies/ipni.strategy.ts:248` so the outer `ipni_tracking_failed` log carries the actual reason instead of `root CID not verified`
- Today, every IPNI breach (timeout, missing expected provider, HTTP fetch error, parse error) ends up with the same generic message in BS, even though one log-line earlier `ipni_root_cid_verification_failed` already populates a `failureReason` field correctly. The outer log loses it during rethrow.

## Why

beck-8 reported that the generic message makes SP-side troubleshooting impossible. After this PR, the same failed deal will surface "IPNI verification timed out after 60000ms" / "Missing expected provider(s): ..." / "Failed to query IPNI indexer: ..." at the catch site instead of "root CID not verified".

See dealbot#473 audit comment: https://github.com/FilOzone/dealbot/issues/473#issuecomment-4336343553 for the full investigation including evidence that all visible IPNI failures are real SLO breaches with reasons that are already captured by the verify code path but lost at this single rethrow.

## Test plan

- [x] `pnpm exec vitest run src/deal-addons/strategies/ipni.strategy.spec.ts` -> 11/11 pass (no test asserts on the old message string)
- [x] No behavior change at the IpniStatus / Deal entity level: still throws, still marks `IpniStatus.FAILED`, still records `failure.timedout` metric. Only the error message changes.
- [ ] Manual: post-deploy, confirm `ipni_tracking_failed` events in BS now show `failureReason` content matching `ipni_root_cid_verification_failed` for the same deal.