### PR TITLE
feat(ipni): expose failureReason as top-level field on ipni_tracking_failed

### DIFF
--- a/apps/backend/src/deal-addons/strategies/ipni.strategy.ts
+++ b/apps/backend/src/deal-addons/strategies/ipni.strategy.ts
@@ -258,6 +258,7 @@ export class IpniAddonStrategy implements IDealAddon<IpniMetadata> {
           ...dealLogContext,
           event: "ipni_tracking_failed",
           message: "IPNI tracking failed",
+          failureReason: error instanceof Error ? error.message : String(error),
           error: toStructuredError(error),
         });
       } catch (saveError) {

--- a/apps/backend/src/deal-addons/strategies/ipni.strategy.ts
+++ b/apps/backend/src/deal-addons/strategies/ipni.strategy.ts
@@ -258,7 +258,12 @@ export class IpniAddonStrategy implements IDealAddon<IpniMetadata> {
           ...dealLogContext,
           event: "ipni_tracking_failed",
           message: "IPNI tracking failed",
-          failureReason: error instanceof Error ? error.message : String(error),
+          failureReason:
+            error instanceof Error
+              ? error.cause instanceof Error
+                ? error.cause.message
+                : error.message
+              : String(error),
           error: toStructuredError(error),
         });
       } catch (saveError) {


### PR DESCRIPTION
## Summary

- Adds a top-level `failureReason` field to the `ipni_tracking_failed` structured log alongside the existing `error: toStructuredError(error)` blob
- Lets BS / Grafana / dashboards filter and aggregate by reason class (timeout vs missing-expected-provider vs HTTP fetch error vs parse error) without JSON-extracting through `error.message`
- No behavior change

## Why

`toStructuredError(error)` nests the underlying message inside `error.message`, which means every BS query that wants to group by reason has to drill into the nested struct. Promoting the message to a top-level field is friction-free for operators and SPs.

Companion to #490 (which makes the underlying message carry the actual reason instead of "root CID not verified").

See dealbot#473 audit comment for the full investigation: https://github.com/FilOzone/dealbot/issues/473#issuecomment-4336343553

## Test plan

- [x] `pnpm exec vitest run src/deal-addons/strategies/ipni.strategy.spec.ts` -> 11/11 pass
- [x] No assertion regressions; `failureReason` is additive
- [ ] Manual: post-deploy, BS query `WHERE event = 'ipni_tracking_failed' GROUP BY failureReason` should bucket failures cleanly without parsing nested fields