### PR TITLE
fix(deal): cancel onStored addons when upload fails

### DIFF
--- a/apps/backend/src/deal/deal.service.spec.ts
+++ b/apps/backend/src/deal/deal.service.spec.ts
@@ -9,7 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, Mock, vi } from "vitest";
 import { ClickhouseService } from "../clickhouse/clickhouse.service.js";
 import { Deal } from "../database/entities/deal.entity.js";
 import { StorageProvider } from "../database/entities/storage-provider.entity.js";
-import { DealStatus } from "../database/types.js";
+import { DealStatus, IpniStatus } from "../database/types.js";
 import { DataSourceService } from "../dataSource/dataSource.service.js";
 import { DealAddonsService } from "../deal-addons/deal-addons.service.js";
 import { DealPreprocessingResult } from "../deal-addons/types.js";
@@ -775,14 +775,17 @@ describe("DealService", () => {
       let capturedAddonSignal: AbortSignal | undefined;
       let addonSettled = false;
       dealAddonsMock.handleStored.mockImplementation(
-        (_deal: Deal, _addons: unknown, sig: AbortSignal) =>
-          new Promise<void>((_, reject) => {
+        (deal: Deal, _addons: unknown, sig: AbortSignal) => {
+          /** Mirror IpniAddonStrategy.onStored which sets PENDING before awaiting. */
+          deal.ipniStatus = IpniStatus.PENDING;
+          return new Promise<void>((_, reject) => {
             capturedAddonSignal = sig;
             sig.addEventListener("abort", () => {
               addonSettled = true;
               reject(sig.reason);
             });
-          }),
+          });
+        },
       );
 
       const commitError = new Error("StorageContext commit: 409 Conflict");
@@ -798,6 +801,8 @@ describe("DealService", () => {
       expect(capturedAddonSignal?.aborted).toBe(true);
       expect(addonSettled).toBe(true);
       expect(mockDeal.status).toBe(DealStatus.FAILED);
+      /** Aborted runs must not leave ipniStatus = PENDING — would depress sp_performance.ipni_success_rate. */
+      expect(mockDeal.ipniStatus).toBeNull();
     });
 
     it("fails deal creation when retrievals do not all succeed", async () => {

--- a/apps/backend/src/deal/deal.service.spec.ts
+++ b/apps/backend/src/deal/deal.service.spec.ts
@@ -763,6 +763,43 @@ describe("DealService", () => {
       expect(retrievalAddonsMock.testAllRetrievalMethods).not.toHaveBeenCalled();
     });
 
+    /** Regression for #503: detached onStored addons must be aborted when executeUpload throws. */
+    it("aborts in-flight onStored addons when executeUpload fails after onStored fires", async () => {
+      const uploadPayload = {
+        carData: Uint8Array.from([1, 2, 3]),
+        rootCid: CID.parse(mockRootCid),
+      };
+
+      createContextMock.mockResolvedValue({ dataSetId: "dataset-123" });
+
+      let capturedAddonSignal: AbortSignal | undefined;
+      let addonSettled = false;
+      dealAddonsMock.handleStored.mockImplementation(
+        (_deal: Deal, _addons: unknown, sig: AbortSignal) =>
+          new Promise<void>((_, reject) => {
+            capturedAddonSignal = sig;
+            sig.addEventListener("abort", () => {
+              addonSettled = true;
+              reject(sig.reason);
+            });
+          }),
+      );
+
+      const commitError = new Error("StorageContext commit: 409 Conflict");
+      (executeUpload as Mock).mockImplementation(async (_s, _d, _c, options) => {
+        await options?.onProgress?.({ type: "onStored", data: { pieceCid: "bafk-uploaded" } });
+        throw commitError;
+      });
+
+      await expect(
+        service.createDeal(mockSynapseInstance, mockProviderInfo, mockDealInput, uploadPayload),
+      ).rejects.toBe(commitError);
+
+      expect(capturedAddonSignal?.aborted).toBe(true);
+      expect(addonSettled).toBe(true);
+      expect(mockDeal.status).toBe(DealStatus.FAILED);
+    });
+
     it("fails deal creation when retrievals do not all succeed", async () => {
       const uploadPayload = {
         carData: Uint8Array.from([1, 2, 3]),

--- a/apps/backend/src/deal/deal.service.spec.ts
+++ b/apps/backend/src/deal/deal.service.spec.ts
@@ -774,19 +774,17 @@ describe("DealService", () => {
 
       let capturedAddonSignal: AbortSignal | undefined;
       let addonSettled = false;
-      dealAddonsMock.handleStored.mockImplementation(
-        (deal: Deal, _addons: unknown, sig: AbortSignal) => {
-          /** Mirror IpniAddonStrategy.onStored which sets PENDING before awaiting. */
-          deal.ipniStatus = IpniStatus.PENDING;
-          return new Promise<void>((_, reject) => {
-            capturedAddonSignal = sig;
-            sig.addEventListener("abort", () => {
-              addonSettled = true;
-              reject(sig.reason);
-            });
+      dealAddonsMock.handleStored.mockImplementation((deal: Deal, _addons: unknown, sig: AbortSignal) => {
+        /** Mirror IpniAddonStrategy.onStored which sets PENDING before awaiting. */
+        deal.ipniStatus = IpniStatus.PENDING;
+        return new Promise<void>((_, reject) => {
+          capturedAddonSignal = sig;
+          sig.addEventListener("abort", () => {
+            addonSettled = true;
+            reject(sig.reason);
           });
-        },
-      );
+        });
+      });
 
       const commitError = new Error("StorageContext commit: 409 Conflict");
       (executeUpload as Mock).mockImplementation(async (_s, _d, _c, options) => {

--- a/apps/backend/src/deal/deal.service.ts
+++ b/apps/backend/src/deal/deal.service.ts
@@ -226,6 +226,7 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
     const addonSignal: AbortSignal = signal ? AbortSignal.any([signal, addonAbortCtrl.signal]) : addonAbortCtrl.signal;
     /** Wrapper object so TS preserves the union type across closure mutation. */
     const onStoredAddons: { promise: Promise<boolean> | null } = { promise: null };
+    let addonsAwaited = false;
     let storedError: Error | undefined;
 
     try {
@@ -436,6 +437,7 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
       // wait for onStored handlers to complete
       if (onStoredAddons.promise != null) {
         const storedOk = await onStoredAddons.promise;
+        addonsAwaited = true;
         if (!storedOk) {
           throw storedError ?? new Error("Upload completion handlers failed");
         }
@@ -533,7 +535,7 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
 
       throw error;
     } finally {
-      if (onStoredAddons.promise != null) {
+      if (!addonsAwaited && onStoredAddons.promise != null) {
         const pending = onStoredAddons.promise;
         addonAbortCtrl.abort();
         await pending.catch(() => {});

--- a/apps/backend/src/deal/deal.service.ts
+++ b/apps/backend/src/deal/deal.service.ts
@@ -223,9 +223,7 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
 
     /** Cancels detached onStored addons when executeUpload fails. See #503. */
     const addonAbortCtrl = new AbortController();
-    const addonSignal: AbortSignal = signal
-      ? AbortSignal.any([signal, addonAbortCtrl.signal])
-      : addonAbortCtrl.signal;
+    const addonSignal: AbortSignal = signal ? AbortSignal.any([signal, addonAbortCtrl.signal]) : addonAbortCtrl.signal;
     /** Wrapper object so TS preserves the union type across closure mutation. */
     const onStoredAddons: { promise: Promise<boolean> | null } = { promise: null };
     let storedError: Error | undefined;

--- a/apps/backend/src/deal/deal.service.ts
+++ b/apps/backend/src/deal/deal.service.ts
@@ -221,6 +221,14 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
       ipfsRootCID: uploadPayload.rootCid.toString(),
     };
 
+    /** Cancels detached onStored addons when executeUpload fails. See #503. */
+    const addonAbortCtrl = new AbortController();
+    const addonSignal: AbortSignal = signal
+      ? AbortSignal.any([signal, addonAbortCtrl.signal])
+      : addonAbortCtrl.signal;
+    let onStoredAddonsPromise: Promise<boolean> | null = null;
+    let storedError: Error | undefined;
+
     try {
       // Load storageProvider relation
       deal.storageProvider = await this.storageProviderRepository.findOne({
@@ -253,8 +261,6 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
 
       deal.dataSetId = storage.dataSetId ?? null;
       deal.uploadStartTime = new Date();
-      let onStoredAddonsPromise: Promise<boolean> | null = null;
-      let storedError: Error | undefined;
 
       const uploadResult = await executeUpload(synapse, uploadPayload.carData, uploadPayload.rootCid, {
         logger: filecoinPinLogger,
@@ -334,7 +340,7 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
               this.dataStorageMetrics.recordUploadStatus(providerLabels, "success");
               this.dataStorageMetrics.recordOnchainStatus(providerLabels, "pending");
               onStoredAddonsPromise = this.dealAddonsService
-                .handleStored(deal, dealInput.appliedAddons, signal, dealLogContext)
+                .handleStored(deal, dealInput.appliedAddons, addonSignal, dealLogContext)
                 .then(() => true)
                 .catch((error) => {
                   storedError = error;
@@ -529,6 +535,10 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
 
       throw error;
     } finally {
+      if (onStoredAddonsPromise != null) {
+        addonAbortCtrl.abort();
+        await onStoredAddonsPromise.catch(() => {});
+      }
       await this.saveDeal(deal, dealLogContext);
     }
   }

--- a/apps/backend/src/deal/deal.service.ts
+++ b/apps/backend/src/deal/deal.service.ts
@@ -226,7 +226,8 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
     const addonSignal: AbortSignal = signal
       ? AbortSignal.any([signal, addonAbortCtrl.signal])
       : addonAbortCtrl.signal;
-    let onStoredAddonsPromise: Promise<boolean> | null = null;
+    /** Wrapper object so TS preserves the union type across closure mutation. */
+    const onStoredAddons: { promise: Promise<boolean> | null } = { promise: null };
     let storedError: Error | undefined;
 
     try {
@@ -339,7 +340,7 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
               uploadSucceeded = true;
               this.dataStorageMetrics.recordUploadStatus(providerLabels, "success");
               this.dataStorageMetrics.recordOnchainStatus(providerLabels, "pending");
-              onStoredAddonsPromise = this.dealAddonsService
+              onStoredAddons.promise = this.dealAddonsService
                 .handleStored(deal, dealInput.appliedAddons, addonSignal, dealLogContext)
                 .then(() => true)
                 .catch((error) => {
@@ -435,9 +436,8 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
       this.updateDealWithUploadResult(deal, uploadResult, uploadPayload.carData.length);
 
       // wait for onStored handlers to complete
-      if (onStoredAddonsPromise != null) {
-        const storedOk = await onStoredAddonsPromise;
-        onStoredAddonsPromise = null;
+      if (onStoredAddons.promise != null) {
+        const storedOk = await onStoredAddons.promise;
         if (!storedOk) {
           throw storedError ?? new Error("Upload completion handlers failed");
         }
@@ -535,9 +535,14 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
 
       throw error;
     } finally {
-      if (onStoredAddonsPromise != null) {
+      if (onStoredAddons.promise != null) {
+        const pending = onStoredAddons.promise;
         addonAbortCtrl.abort();
-        await onStoredAddonsPromise.catch(() => {});
+        await pending.catch(() => {});
+        if (deal.status === DealStatus.FAILED) {
+          /** Clear PENDING ipniStatus left by IpniAddonStrategy.onStored so aborted runs don't depress sp_performance.ipni_success_rate. See #503. */
+          deal.ipniStatus = null;
+        }
       }
       await this.saveDeal(deal, dealLogContext);
     }

--- a/apps/backend/src/deal/deal.service.ts
+++ b/apps/backend/src/deal/deal.service.ts
@@ -21,7 +21,7 @@ import type { DataFile, Hex } from "../common/types.js";
 import type { IBlockchainConfig, IConfig } from "../config/app.config.js";
 import { Deal } from "../database/entities/deal.entity.js";
 import { StorageProvider } from "../database/entities/storage-provider.entity.js";
-import { DealStatus, ServiceType } from "../database/types.js";
+import { DealStatus, IpniStatus, ServiceType } from "../database/types.js";
 import { DataSourceService } from "../dataSource/dataSource.service.js";
 import { DealAddonsService } from "../deal-addons/deal-addons.service.js";
 import type { DealPreprocessingResult } from "../deal-addons/types.js";
@@ -539,8 +539,8 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
         const pending = onStoredAddons.promise;
         addonAbortCtrl.abort();
         await pending.catch(() => {});
-        if (deal.status === DealStatus.FAILED) {
-          /** Clear PENDING ipniStatus left by IpniAddonStrategy.onStored so aborted runs don't depress sp_performance.ipni_success_rate. See #503. */
+        if (deal.ipniStatus === IpniStatus.PENDING) {
+          /** Addon aborted before reaching terminal IpniStatus. Clear so this run doesn't depress sp_performance.ipni_success_rate. Leaves real FAILED/VERIFIED untouched. See #503. */
           deal.ipniStatus = null;
         }
       }


### PR DESCRIPTION
## What changed

`StorageContext.upload()` in `@filoz/synapse-sdk` fires the `onStored` callback before `commit()`/`addPieces`, so dealbot's IPNI monitoring (started inside `onStored`) runs detached from the main upload flow. When `executeUpload` throws afterward (e.g. a 409 on `POST /pdp/data-sets/{id}/pieces` against a Curio-terminated dataset), the deal already failed but the IPNI poll keeps running for its 120s timeout and emits a misleading `ipni_tracking_failed` event.

This wires an `AbortController` for the detached addons, composed with the parent signal via `AbortSignal.any`. On upload failure the `finally` block aborts and drains the pending addon promise. IPNI's existing `signal?.throwIfAborted()` guards (`ipni.strategy.ts:255`, `deal-addons.service.ts:193`) suppress the spurious failure log/metric.

Closes #503.

## How to verify

```
cd apps/backend && pnpm test -- --run src/deal/deal.service.spec.ts
```

New regression test: `aborts in-flight onStored addons when executeUpload fails after onStored fires`.

## Notes

Underlying terminated-dataset reuse (#379) is unaffected. The race window where the SDK reuses a Curio-terminated dataset still happens; this fix bounds blast radius (no leaked 120s poll, no spurious metric) but does not prevent the first failure.