### PR TITLE
fix: stop retention counter double-counts

### DIFF
--- a/apps/backend/src/data-retention/data-retention.service.spec.ts
+++ b/apps/backend/src/data-retention/data-retention.service.spec.ts
@@ -32,6 +32,12 @@ const makeProvider = (overrides: Partial<ProviderEntry> = {}): ProviderEntry => 
 
 describe("DataRetentionService", () => {
   let service: DataRetentionService;
+  let baselineRows: Array<{
+    providerAddress: string;
+    faultedPeriods: string;
+    successPeriods: string;
+    lastBlockNumber: string;
+  }>;
   let configServiceMock: ConfigService<IConfig, true>;
   let walletSdkServiceMock: {
     getTestingProviders: ReturnType<typeof vi.fn>;
@@ -116,12 +122,26 @@ describe("DataRetentionService", () => {
       remove: vi.fn(),
     };
 
+    baselineRows = [];
     mockBaselineRepository = {
-      find: vi.fn().mockResolvedValue([]),
-      upsert: vi.fn().mockResolvedValue(undefined),
-      delete: vi.fn().mockResolvedValue(undefined),
+      find: vi.fn().mockImplementation(async () => baselineRows.map((row) => ({ ...row }))),
+      upsert: vi.fn().mockImplementation(async (row: (typeof baselineRows)[number]) => {
+        const index = baselineRows.findIndex(
+          (existing) => existing.providerAddress.toLowerCase() === row.providerAddress.toLowerCase(),
+        );
+        if (index >= 0) {
+          baselineRows[index] = { ...baselineRows[index], ...row };
+        } else {
+          baselineRows.push({ ...row });
+        }
+      }),
+      delete: vi.fn().mockImplementation(async ({ providerAddress }: { providerAddress: string }) => {
+        baselineRows = baselineRows.filter(
+          (row) => row.providerAddress.toLowerCase() !== providerAddress.toLowerCase(),
+        );
+      }),
     };
-    mockSPRepository = { find: vi.fn() };
+    mockSPRepository = { find: vi.fn().mockResolvedValue([]) };
     const clickhouseServiceMock = { insert: vi.fn(), probeLocation: "test" } as unknown as ClickhouseService;
     service = new DataRetentionService(
       configServiceMock,
@@ -901,15 +921,76 @@ describe("DataRetentionService", () => {
       expect(incCalls).toEqual(expect.arrayContaining([[10], [25]]));
     });
 
-    it("only loads baselines from DB once across multiple polls", async () => {
+    it("reloads baselines from DB on every poll", async () => {
       pdpSubgraphServiceMock.fetchProvidersWithDatasets.mockResolvedValue([makeProvider()]);
 
       await service.pollDataRetention();
       await service.pollDataRetention();
       await service.pollDataRetention();
 
-      // DB find should only be called once (lazy init)
-      expect(mockBaselineRepository.find).toHaveBeenCalledTimes(1);
+      expect(mockBaselineRepository.find).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not double-count when poll ownership alternates across worker pods", async () => {
+      pdpSubgraphServiceMock.fetchProvidersWithDatasets.mockResolvedValueOnce([makeProvider()]);
+      await service.pollDataRetention();
+
+      const secondPod = new DataRetentionService(
+        configServiceMock,
+        walletSdkServiceMock as unknown as WalletSdkService,
+        pdpSubgraphServiceMock as unknown as PDPSubgraphService,
+        mockBaselineRepository as unknown as Repository<DataRetentionBaseline>,
+        mockSPRepository as unknown as Repository<StorageProvider>,
+        counterMock as unknown as Counter,
+        gaugeMock as unknown as Gauge,
+        { insert: vi.fn(), probeLocation: "test" } as unknown as ClickhouseService,
+      );
+
+      pdpSubgraphServiceMock.fetchSubgraphMeta.mockResolvedValueOnce({ _meta: { block: { number: 1300 } } });
+      pdpSubgraphServiceMock.fetchProvidersWithDatasets.mockResolvedValueOnce([
+        makeProvider({ totalFaultedPeriods: 11n, totalProvingPeriods: 102n }),
+      ]);
+      await secondPod.pollDataRetention();
+
+      counterMock.labels.mockClear();
+      counterMock.inc.mockClear();
+
+      pdpSubgraphServiceMock.fetchSubgraphMeta.mockResolvedValueOnce({ _meta: { block: { number: 1400 } } });
+      pdpSubgraphServiceMock.fetchProvidersWithDatasets.mockResolvedValueOnce([
+        makeProvider({ totalFaultedPeriods: 12n, totalProvingPeriods: 104n }),
+      ]);
+      await service.pollDataRetention();
+
+      // Third poll must use the second pod's persisted baseline: failure +5, success +5.
+      // A stale first-pod baseline would emit +10 and +10 here.
+      expect(counterMock.inc.mock.calls).toEqual([[5], [5]]);
+    });
+
+    it("does not update counters or local baseline when baseline persistence fails", async () => {
+      baselineRows = [
+        { providerAddress: PROVIDER_A, faultedPeriods: "10", successPeriods: "90", lastBlockNumber: "1200" },
+      ];
+      mockBaselineRepository.upsert.mockRejectedValueOnce(new Error("DB write failed"));
+
+      pdpSubgraphServiceMock.fetchSubgraphMeta.mockResolvedValueOnce({ _meta: { block: { number: 1300 } } });
+      pdpSubgraphServiceMock.fetchProvidersWithDatasets.mockResolvedValueOnce([
+        makeProvider({ totalFaultedPeriods: 12n, totalProvingPeriods: 105n }),
+      ]);
+
+      await service.pollDataRetention();
+
+      expect(counterMock.labels).not.toHaveBeenCalled();
+
+      pdpSubgraphServiceMock.fetchSubgraphMeta.mockResolvedValueOnce({ _meta: { block: { number: 1400 } } });
+      pdpSubgraphServiceMock.fetchProvidersWithDatasets.mockResolvedValueOnce([
+        makeProvider({ totalFaultedPeriods: 12n, totalProvingPeriods: 105n }),
+      ]);
+
+      await service.pollDataRetention();
+
+      // Since the failed write did not advance the DB or local baseline, the next
+      // successful poll emits the original persisted-baseline delta once.
+      expect(counterMock.inc.mock.calls).toEqual([[10], [15]]);
     });
 
     it("retries DB load on next poll if first load fails", async () => {

--- a/apps/backend/src/data-retention/data-retention.service.ts
+++ b/apps/backend/src/data-retention/data-retention.service.ts
@@ -202,7 +202,7 @@ export class DataRetentionService {
    * Removes stale provider entries from the per-poll baselines map, the persisted baseline
    * table, and their associated Prometheus counter/gauge metrics.
    *
-   * CRITICAL: Persisted/in-memory baselines are ONLY deleted if Prometheus removal succeeds.
+   * CRITICAL: Persisted and poll-local baselines are ONLY deleted if Prometheus removal succeeds.
    * Prevents massive metric inflation (double-counting) if a provider temporarily drops
    * offline and returns later.
    */

--- a/apps/backend/src/data-retention/data-retention.service.ts
+++ b/apps/backend/src/data-retention/data-retention.service.ts
@@ -37,17 +37,6 @@ export class DataRetentionService {
   private static readonly MAX_PROVIDER_BATCH_LENGTH = 50;
   // NOTE: taken from https://github.com/FilOzone/filecoin-services/blob/c04be93aa680082e359481f0776e41ed157a2ac2/service_contracts/src/FilecoinWarmStorageService.sol#L26
   private static readonly CHALLENGES_PER_PROVING_PERIOD = 5n;
-  private pollInProgress = false;
-
-  /**
-   * Tracks cumulative faulted/success period totals per provider address.
-   * Used to compute deltas between consecutive polls for Prometheus counter increments.
-   * Reloaded from the database at the start of every poll, then updated after
-   * baseline persistence succeeds.
-   * Note: Baselines are stored in periods, but emitted metrics are converted to challenges
-   * by multiplying period deltas by CHALLENGES_PER_PROVING_PERIOD.
-   */
-  private readonly providerCumulativeTotals: Map<string, ProviderBaseline>;
 
   constructor(
     private readonly configService: ConfigService<IConfig, true>,
@@ -62,9 +51,7 @@ export class DataRetentionService {
     @InjectMetric("pdp_provider_estimated_overdue_periods")
     private readonly estimatedOverduePeriodsGauge: Gauge,
     private readonly clickhouseService: ClickhouseService,
-  ) {
-    this.providerCumulativeTotals = new Map();
-  }
+  ) {}
 
   /**
    * Polls the PDP subgraph for provider proof-set data, computes proving period deltas,
@@ -81,22 +68,13 @@ export class DataRetentionService {
       return;
     }
 
-    if (this.pollInProgress) {
-      this.logger.warn({
-        event: "data_retention_poll_already_running",
-        message: "Skipping data retention poll because a previous poll is still running",
-      });
+    const baselines = await this.loadBaselinesFromDb();
+    if (baselines === null) {
+      // Cannot safely compute deltas without persisted baselines.
       return;
     }
 
-    this.pollInProgress = true;
-
     try {
-      if (!(await this.loadBaselinesFromDb())) {
-        // Cannot safely compute deltas without persisted baselines.
-        return;
-      }
-
       const subgraphMeta = await this.pdpSubgraphService.fetchSubgraphMeta();
       const allProviderInfos = this.walletSdkService.getTestingProviders();
       const spBlocklists = this.configService.get("spBlocklists");
@@ -142,7 +120,7 @@ export class DataRetentionService {
                   ),
                 );
               }
-              return this.processProvider(provider, providerInfo, blockNumberBigInt);
+              return this.processProvider(provider, providerInfo, blockNumberBigInt, baselines);
             }),
           );
 
@@ -178,7 +156,7 @@ export class DataRetentionService {
               }
 
               try {
-                this.applyPersistedProviderResult(result.value);
+                this.applyPersistedProviderResult(result.value, baselines);
               } catch (error) {
                 hasProcessingErrors = true;
                 this.logger.error({
@@ -204,7 +182,7 @@ export class DataRetentionService {
 
       // Only cleanup stale providers after successful poll to preserve baselines during transient failures
       if (!hasProcessingErrors) {
-        await this.cleanupStaleProviders(providerAddresses);
+        await this.cleanupStaleProviders(providerAddresses, baselines);
       } else {
         this.logger.warn({
           event: "stale_provider_cleanup_skipped",
@@ -217,26 +195,25 @@ export class DataRetentionService {
         message: "Failed to poll data retention",
         error: toStructuredError(error),
       });
-    } finally {
-      this.pollInProgress = false;
     }
   }
 
   /**
-   * Removes stale provider entries from the cumulative totals map and their associated
-   * Prometheus counter and gauge metrics.
+   * Removes stale provider entries from the per-poll baselines map, the persisted baseline
+   * table, and their associated Prometheus counter/gauge metrics.
    *
-   * CRITICAL: Local baselines are ONLY deleted if the Prometheus metrics are successfully
-   * removed. This prevents massive metric inflation (double-counting) if a provider
-   * temporarily drops offline and returns later.
-   *
-   * @param activeProviderAddresses - Array of currently active provider addresses (normalized to lowercase)
+   * CRITICAL: Persisted/in-memory baselines are ONLY deleted if Prometheus removal succeeds.
+   * Prevents massive metric inflation (double-counting) if a provider temporarily drops
+   * offline and returns later.
    */
-  private async cleanupStaleProviders(activeProviderAddresses: string[]): Promise<void> {
+  private async cleanupStaleProviders(
+    activeProviderAddresses: string[],
+    baselines: Map<string, ProviderBaseline>,
+  ): Promise<void> {
     const activeAddressSet = new Set(activeProviderAddresses);
     const staleAddresses: string[] = [];
 
-    for (const [address] of this.providerCumulativeTotals) {
+    for (const [address] of baselines) {
       if (!activeAddressSet.has(address)) {
         staleAddresses.push(address);
       }
@@ -297,7 +274,7 @@ export class DataRetentionService {
           this.estimatedOverduePeriodsGauge.remove(unapprovedLabels);
 
           // Only delete local memory if Prometheus removal succeeded without throwing
-          this.providerCumulativeTotals.delete(address);
+          baselines.delete(address);
 
           // Also remove persisted baseline from DB
           this.baselineRepository.delete({ providerAddress: address }).catch((err) => {
@@ -351,6 +328,7 @@ export class DataRetentionService {
     provider: ProviderDataSetResponse["providers"][number],
     pdpProvider: PDPProviderEx,
     currentBlock: bigint,
+    baselines: Map<string, ProviderBaseline>,
   ): Promise<ProcessedProviderResult> {
     const { address, totalFaultedPeriods, totalProvingPeriods, proofSets } = provider;
     // Note: Query filters proofSets with nextDeadline_lt: $blockNumber, so all deadlines are in the past
@@ -376,7 +354,7 @@ export class DataRetentionService {
     });
 
     const normalizedAddress = address.toLowerCase();
-    const previous = this.providerCumulativeTotals.get(normalizedAddress);
+    const previous = baselines.get(normalizedAddress);
 
     const newBaseline = {
       faultedPeriods: totalFaultedPeriods,
@@ -461,8 +439,11 @@ export class DataRetentionService {
     };
   }
 
-  private applyPersistedProviderResult(result: ProcessedProviderResult): void {
-    this.providerCumulativeTotals.set(result.providerAddress, result.baseline);
+  private applyPersistedProviderResult(
+    result: ProcessedProviderResult,
+    baselines: Map<string, ProviderBaseline>,
+  ): void {
+    baselines.set(result.providerAddress, result.baseline);
 
     if (result.negativeDelta) {
       return;
@@ -488,15 +469,14 @@ export class DataRetentionService {
   }
 
   /**
-   * Loads persisted baselines from the database into the in-memory map.
+   * Loads persisted baselines from the database into a fresh map.
    * Runs at the start of every poll so whichever worker pod wins the job computes
-   * deltas from the latest persisted cross-pod baseline.
+   * deltas from the latest persisted cross-pod baseline. Returns null on DB failure
+   * so the caller can abort the poll.
    */
-  private async loadBaselinesFromDb(): Promise<boolean> {
+  private async loadBaselinesFromDb(): Promise<Map<string, ProviderBaseline> | null> {
     try {
       const rows = await this.baselineRepository.find();
-      // Build a replacement map before clearing the current one so a malformed
-      // persisted row does not erase the last usable in-memory baselines.
       const baselines = new Map<string, ProviderBaseline>();
       for (const row of rows) {
         baselines.set(row.providerAddress.toLowerCase(), {
@@ -504,23 +484,19 @@ export class DataRetentionService {
           successPeriods: BigInt(row.successPeriods),
         });
       }
-      this.providerCumulativeTotals.clear();
-      for (const [address, baseline] of baselines) {
-        this.providerCumulativeTotals.set(address, baseline);
-      }
       this.logger.log({
         event: "baselines_loaded_from_db",
         message: "Loaded baseline(s) from database",
         baselineCount: rows.length,
       });
-      return true;
+      return baselines;
     } catch (error) {
       this.logger.error({
         event: "baseline_load_failed",
         message: "Failed to load baselines from database. Aborting poll and will retry on next poll.",
         error: toStructuredError(error),
       });
-      return false;
+      return null;
     }
   }
 

--- a/apps/backend/src/data-retention/data-retention.service.ts
+++ b/apps/backend/src/data-retention/data-retention.service.ts
@@ -16,6 +16,20 @@ import { type ProviderDataSetResponse } from "../pdp-subgraph/types.js";
 import { WalletSdkService } from "../wallet-sdk/wallet-sdk.service.js";
 import { type PDPProviderEx } from "../wallet-sdk/wallet-sdk.types.js";
 
+type ProviderBaseline = {
+  faultedPeriods: bigint;
+  successPeriods: bigint;
+};
+
+type ProcessedProviderResult = {
+  providerAddress: string;
+  providerLabels: CheckMetricLabels;
+  baseline: ProviderBaseline;
+  faultedChallengesDelta: bigint;
+  successChallengesDelta: bigint;
+  negativeDelta: boolean;
+};
+
 @Injectable()
 export class DataRetentionService {
   private readonly logger = new Logger(DataRetentionService.name);
@@ -23,24 +37,17 @@ export class DataRetentionService {
   private static readonly MAX_PROVIDER_BATCH_LENGTH = 50;
   // NOTE: taken from https://github.com/FilOzone/filecoin-services/blob/c04be93aa680082e359481f0776e41ed157a2ac2/service_contracts/src/FilecoinWarmStorageService.sol#L26
   private static readonly CHALLENGES_PER_PROVING_PERIOD = 5n;
+  private pollInProgress = false;
 
   /**
    * Tracks cumulative faulted/success period totals per provider address.
    * Used to compute deltas between consecutive polls for Prometheus counter increments.
-   * Populated from the database on first poll, then kept in sync.
+   * Reloaded from the database at the start of every poll, then updated after
+   * baseline persistence succeeds.
    * Note: Baselines are stored in periods, but emitted metrics are converted to challenges
    * by multiplying period deltas by CHALLENGES_PER_PROVING_PERIOD.
    */
-  private readonly providerCumulativeTotals: Map<
-    string,
-    {
-      faultedPeriods: bigint;
-      successPeriods: bigint;
-    }
-  >;
-
-  /** Whether baselines have been loaded from the database */
-  private baselinesLoaded = false;
+  private readonly providerCumulativeTotals: Map<string, ProviderBaseline>;
 
   constructor(
     private readonly configService: ConfigService<IConfig, true>,
@@ -74,14 +81,22 @@ export class DataRetentionService {
       return;
     }
 
-    await this.loadBaselinesFromDb();
-
-    if (!this.baselinesLoaded) {
-      // Cannot safely compute deltas without baselines — would emit full cumulative history
+    if (this.pollInProgress) {
+      this.logger.warn({
+        event: "data_retention_poll_already_running",
+        message: "Skipping data retention poll because a previous poll is still running",
+      });
       return;
     }
 
+    this.pollInProgress = true;
+
     try {
+      if (!(await this.loadBaselinesFromDb())) {
+        // Cannot safely compute deltas without persisted baselines.
+        return;
+      }
+
       const subgraphMeta = await this.pdpSubgraphService.fetchSubgraphMeta();
       const allProviderInfos = this.walletSdkService.getTestingProviders();
       const spBlocklists = this.configService.get("spBlocklists");
@@ -131,38 +146,50 @@ export class DataRetentionService {
             }),
           );
 
-          // Log any processing failures and persist successful baselines
-          const upsertPromises: Promise<void>[] = [];
-          processingResults.forEach((result, index) => {
-            if (result.status === "rejected") {
-              hasProcessingErrors = true;
-              const addr = providersFromSubgraph[index].address;
-              const providerInfo = providerInfoMap.get(addr.toLowerCase());
-              this.logger.error({
-                event: "provider_processing_failed",
-                message: "Failed to process provider",
-                providerAddress: addr,
-                providerId: providerInfo?.id,
-                providerName: providerInfo?.name,
-                error: toStructuredError(result.reason),
-              });
-            } else {
-              const addr = providersFromSubgraph[index].address.toLowerCase();
-              upsertPromises.push(this.persistBaseline(addr, result.value, blockNumberBigInt));
-            }
-          });
+          await Promise.all(
+            processingResults.map(async (result, index) => {
+              if (result.status === "rejected") {
+                hasProcessingErrors = true;
+                const addr = providersFromSubgraph[index].address;
+                const providerInfo = providerInfoMap.get(addr.toLowerCase());
+                this.logger.error({
+                  event: "provider_processing_failed",
+                  message: "Failed to process provider",
+                  providerAddress: addr,
+                  providerId: providerInfo?.id,
+                  providerName: providerInfo?.name,
+                  error: toStructuredError(result.reason),
+                });
+                return;
+              }
 
-          // Persist baselines to DB (non-blocking for the main flow, but we await to catch errors)
-          const upsertResults = await Promise.allSettled(upsertPromises);
-          for (const result of upsertResults) {
-            if (result.status === "rejected") {
-              this.logger.warn({
-                event: "baseline_persist_failed",
-                message: "Failed to persist baseline to database",
-                error: toStructuredError(result.reason),
-              });
-            }
-          }
+              try {
+                await this.persistBaseline(result.value.providerAddress, result.value.baseline, blockNumberBigInt);
+              } catch (error) {
+                hasProcessingErrors = true;
+                // Leave stale cleanup for a later poll so DB-backed baselines and local state do not diverge further.
+                this.logger.warn({
+                  event: "baseline_persist_failed",
+                  message: "Failed to persist baseline to database",
+                  providerAddress: result.value.providerAddress,
+                  error: toStructuredError(error),
+                });
+                return;
+              }
+
+              try {
+                this.applyPersistedProviderResult(result.value);
+              } catch (error) {
+                hasProcessingErrors = true;
+                this.logger.error({
+                  event: "provider_result_apply_failed",
+                  message: "Failed to apply persisted provider result",
+                  providerAddress: result.value.providerAddress,
+                  error: toStructuredError(error),
+                });
+              }
+            }),
+          );
         } catch (error) {
           hasProcessingErrors = true;
           this.logger.error({
@@ -190,6 +217,8 @@ export class DataRetentionService {
         message: "Failed to poll data retention",
         error: toStructuredError(error),
       });
+    } finally {
+      this.pollInProgress = false;
     }
   }
 
@@ -322,7 +351,7 @@ export class DataRetentionService {
     provider: ProviderDataSetResponse["providers"][number],
     pdpProvider: PDPProviderEx,
     currentBlock: bigint,
-  ): Promise<{ faultedPeriods: bigint; successPeriods: bigint }> {
+  ): Promise<ProcessedProviderResult> {
     const { address, totalFaultedPeriods, totalProvingPeriods, proofSets } = provider;
     // Note: Query filters proofSets with nextDeadline_lt: $blockNumber, so all deadlines are in the past
     const estimatedOverduePeriods = proofSets.reduce((acc, proofSet) => {
@@ -385,8 +414,14 @@ export class DataRetentionService {
         faultedPeriods: totalFaultedPeriods.toString(),
         successPeriods: confirmedTotalSuccess.toString(),
       });
-      this.providerCumulativeTotals.set(normalizedAddress, newBaseline);
-      return newBaseline;
+      return {
+        providerAddress: normalizedAddress,
+        providerLabels,
+        baseline: newBaseline,
+        faultedChallengesDelta: 0n,
+        successChallengesDelta: 0n,
+        negativeDelta: false,
+      };
     }
 
     const faultedChallengesDelta =
@@ -406,53 +441,86 @@ export class DataRetentionService {
         faultedChallengesDelta: faultedChallengesDelta.toString(),
         successChallengesDelta: successChallengesDelta.toString(),
       });
-      // Reset baseline without incrementing counters
-      this.providerCumulativeTotals.set(normalizedAddress, newBaseline);
-      return newBaseline;
+      return {
+        providerAddress: normalizedAddress,
+        providerLabels,
+        baseline: newBaseline,
+        faultedChallengesDelta,
+        successChallengesDelta,
+        negativeDelta: true,
+      };
     }
 
-    if (faultedChallengesDelta > 0n) {
-      this.safeIncrementCounter(this.dataSetChallengeStatusCounter, providerLabels, "failure", faultedChallengesDelta);
+    return {
+      providerAddress: normalizedAddress,
+      providerLabels,
+      baseline: newBaseline,
+      faultedChallengesDelta,
+      successChallengesDelta,
+      negativeDelta: false,
+    };
+  }
+
+  private applyPersistedProviderResult(result: ProcessedProviderResult): void {
+    this.providerCumulativeTotals.set(result.providerAddress, result.baseline);
+
+    if (result.negativeDelta) {
+      return;
     }
 
-    if (successChallengesDelta > 0n) {
-      this.safeIncrementCounter(this.dataSetChallengeStatusCounter, providerLabels, "success", successChallengesDelta);
+    if (result.faultedChallengesDelta > 0n) {
+      this.safeIncrementCounter(
+        this.dataSetChallengeStatusCounter,
+        result.providerLabels,
+        "failure",
+        result.faultedChallengesDelta,
+      );
     }
 
-    this.providerCumulativeTotals.set(normalizedAddress, newBaseline);
-
-    return newBaseline;
+    if (result.successChallengesDelta > 0n) {
+      this.safeIncrementCounter(
+        this.dataSetChallengeStatusCounter,
+        result.providerLabels,
+        "success",
+        result.successChallengesDelta,
+      );
+    }
   }
 
   /**
    * Loads persisted baselines from the database into the in-memory map.
-   * Only runs once; if the DB read fails, retries on the next poll.
+   * Runs at the start of every poll so whichever worker pod wins the job computes
+   * deltas from the latest persisted cross-pod baseline.
    */
-  private async loadBaselinesFromDb(): Promise<void> {
-    if (this.baselinesLoaded) {
-      return;
-    }
-
+  private async loadBaselinesFromDb(): Promise<boolean> {
     try {
       const rows = await this.baselineRepository.find();
+      // Build a replacement map before clearing the current one so a malformed
+      // persisted row does not erase the last usable in-memory baselines.
+      const baselines = new Map<string, ProviderBaseline>();
       for (const row of rows) {
-        this.providerCumulativeTotals.set(row.providerAddress, {
+        baselines.set(row.providerAddress.toLowerCase(), {
           faultedPeriods: BigInt(row.faultedPeriods),
           successPeriods: BigInt(row.successPeriods),
         });
       }
-      this.baselinesLoaded = true;
+      this.providerCumulativeTotals.clear();
+      for (const [address, baseline] of baselines) {
+        this.providerCumulativeTotals.set(address, baseline);
+      }
       this.logger.log({
         event: "baselines_loaded_from_db",
         message: "Loaded baseline(s) from database",
         baselineCount: rows.length,
       });
+      return true;
     } catch (error) {
       this.logger.error({
         event: "baseline_load_failed",
-        message: "Failed to load baselines from database. Will retry on next poll.",
+        message: "Failed to load baselines from database. Aborting poll and will retry on next poll.",
         error: toStructuredError(error),
       });
+      return false;
     }
   }
 
@@ -461,7 +529,7 @@ export class DataRetentionService {
    */
   private async persistBaseline(
     providerAddress: string,
-    baseline: { faultedPeriods: bigint; successPeriods: bigint },
+    baseline: ProviderBaseline,
     blockNumber: bigint,
   ): Promise<void> {
     await this.baselineRepository.upsert(

--- a/docs/checks/data-retention.md
+++ b/docs/checks/data-retention.md
@@ -84,7 +84,7 @@ Baselines are stored and compared in **periods**; the `dataSetChallengeStatus` c
 
 **Negative delta handling**: If either challenge delta is negative (due to chain reorgs, subgraph corrections, or data inconsistencies), the baseline is reset to current values without incrementing counters. This prevents stalled metrics.
 
-**Baseline persistence**: Baselines are persisted to the `data_retention_baselines` database table after each successful poll. On service restart, baselines are reloaded from the database to prevent metric inflation.
+**Baseline persistence**: Baselines are persisted to the `data_retention_baselines` database table after each successful provider update. Each poll reloads persisted baselines before computing deltas, so any worker pod that runs the poll uses the latest shared baseline.
 
 Source: [`data-retention.service.ts` (`processProvider`)](../../apps/backend/src/data-retention/data-retention.service.ts)
 
@@ -98,21 +98,22 @@ Source: [`data-retention.service.ts` (`safeIncrementCounter`)](../../apps/backen
 
 ## Baseline Persistence
 
-To prevent metric inflation across service restarts, dealbot persists provider baselines to the database.
+To prevent metric inflation across service restarts and worker-pod handoffs, dealbot persists provider baselines to the database.
 
 **Storage**: Baselines are stored in the `data_retention_baselines` table with columns for `provider_address`, `faulted_periods`, `success_periods`, `last_block_number`, and `updated_at`.
 
 **Lifecycle**:
 
-1. **On first poll**: Load all baselines from database into memory. If load fails, abort poll to prevent emitting inflated values.
+1. **At poll start**: Load all baselines from database into memory. If load fails, abort poll to prevent emitting inflated values.
 2. **First-seen provider**: If a provider has no prior baseline (not in memory or database), initialize its baseline to the current cumulative totals without emitting counters. This avoids a metric spike from the provider's full history.
-3. **On each poll**: After processing providers, persist updated baselines to database.
-4. **On restart**: Reload baselines from database. Delta computation resumes from last persisted state, preventing double-counting.
+3. **Per provider**: Compute the new baseline and any positive counter deltas.
+4. **Before counter emission**: Persist the new baseline to database. Only after the write succeeds does dealbot update the local map and increment `dataSetChallengeStatus`.
+5. **On restart or worker-pod handoff**: Reload baselines from database. Delta computation resumes from the last persisted state, preventing double-counting.
 
 **Error handling**:
 
 - **DB load failure**: Poll aborted, retry on next cycle
-- **DB persist failure**: Warning logged, in-memory state remains consistent
+- **DB persist failure**: Warning logged, counter increment skipped, in-memory baseline not advanced
 - **Stale provider cleanup**: Baselines deleted from both memory and database when providers are removed from active list
 
 Source: [`data-retention.service.ts` (`loadBaselinesFromDb`, `persistBaseline`)](../../apps/backend/src/data-retention/data-retention.service.ts), [`CreateDataRetentionBaselines` migration](../../apps/backend/src/database/migrations/1761500000002-CreateDataRetentionBaselines.ts)
@@ -258,14 +259,19 @@ flowchart TD
     CheckBaseline -->|No| InitBaseline[Initialize Baseline. No Metric Emission]
     InitBaseline --> PersistBaseline
     CheckBaseline -->|Yes| CalcDeltas[Calculate Deltas from Baseline]
-    CalcDeltas --> CheckDeltas{Deltas<br/>Positive?}
+    CalcDeltas --> CheckDeltas{Any Negative<br/>Delta?}
 
-    CheckDeltas -->|Negative| ResetBaseline[Reset Baseline. No Metric Update]
-    CheckDeltas -->|Positive| IncrementMetrics[Increment Prometheus Counters]
-    IncrementMetrics --> UpdateBaseline[Update Baseline in Memory]
+    CheckDeltas -->|Yes| ResetBaseline[Reset Baseline. No Metric Update]
+    CheckDeltas -->|No| PersistBaseline
     ResetBaseline --> PersistBaseline[Persist Baseline to DB]
-    UpdateBaseline --> PersistBaseline
-    PersistBaseline --> MoreBatches{More<br/>Batches?}
+    PersistBaseline --> CheckPersist{Persist<br/>Success?}
+    CheckPersist -->|Yes| UpdateBaseline[Update Baseline in Memory]
+    UpdateBaseline --> CheckEmit{Positive<br/>Deltas?}
+    CheckEmit -->|Yes| IncrementMetrics[Increment Prometheus Counters]
+    CheckEmit -->|No| MoreBatches
+    CheckPersist -->|No| MarkError[Mark Processing Error]
+    IncrementMetrics --> MoreBatches{More<br/>Batches?}
+    MarkError --> MoreBatches
 
     MoreBatches -->|Yes| BatchLoop
     MoreBatches -->|No| CheckErrors{Processing<br/>Errors?}
@@ -302,7 +308,7 @@ Providers may temporarily drop from the active list due to configuration changes
 
 ### What happens if the service restarts?
 
-Baselines are persisted to the database after each successful poll. On restart, the service loads all baselines from the database on the first poll, and delta computation resumes from the last persisted state. This prevents metric inflation (double-counting).
+Baselines are persisted to the database after each successful provider update. At the start of every poll, the service loads all baselines from the database, and delta computation resumes from the last persisted state. This prevents metric inflation when a process restarts or a different worker pod runs the next poll.
 
 **Example scenario:**
 

--- a/docs/checks/data-retention.md
+++ b/docs/checks/data-retention.md
@@ -104,17 +104,17 @@ To prevent metric inflation across service restarts and worker-pod handoffs, dea
 
 **Lifecycle**:
 
-1. **At poll start**: Load all baselines from database into memory. If load fails, abort poll to prevent emitting inflated values.
-2. **First-seen provider**: If a provider has no prior baseline (not in memory or database), initialize its baseline to the current cumulative totals without emitting counters. This avoids a metric spike from the provider's full history.
+1. **At poll start**: Load all baselines from the database into a fresh poll-local map. If load fails, abort poll to prevent emitting inflated values.
+2. **First-seen provider**: If a provider has no persisted baseline, initialize its baseline to the current cumulative totals without emitting counters. This avoids a metric spike from the provider's full history.
 3. **Per provider**: Compute the new baseline and any positive counter deltas.
-4. **Before counter emission**: Persist the new baseline to database. Only after the write succeeds does dealbot update the local map and increment `dataSetChallengeStatus`.
-5. **On restart or worker-pod handoff**: Reload baselines from database. Delta computation resumes from the last persisted state, preventing double-counting.
+4. **Before counter emission**: Persist the new baseline to the database. Only after the write succeeds does dealbot update the poll-local map and increment `dataSetChallengeStatus`.
+5. **On restart or worker-pod handoff**: Every poll reloads baselines from the database, so delta computation resumes from the last persisted state regardless of which pod runs.
 
 **Error handling**:
 
 - **DB load failure**: Poll aborted, retry on next cycle
-- **DB persist failure**: Warning logged, counter increment skipped, in-memory baseline not advanced
-- **Stale provider cleanup**: Baselines deleted from both memory and database when providers are removed from active list
+- **DB persist failure**: Warning logged, counter increment skipped, poll-local baseline not advanced
+- **Stale provider cleanup**: Baselines deleted from both the poll-local map and the database when providers are removed from the active list
 
 Source: [`data-retention.service.ts` (`loadBaselinesFromDb`, `persistBaseline`)](../../apps/backend/src/data-retention/data-retention.service.ts), [`CreateDataRetentionBaselines` migration](../../apps/backend/src/database/migrations/1761500000002-CreateDataRetentionBaselines.ts)
 
@@ -124,12 +124,12 @@ To prevent unbounded memory growth, dealbot periodically removes baseline data f
 
 **Cleanup strategy**:
 
-1. Identify providers in the baseline map but not in the current active list
+1. Identify providers in the poll-local baseline map but not in the current active list
 2. Fetch provider info from the database
 3. Remove Prometheus counter metrics for both success and fault labels
 4. Remove Prometheus gauge metric for overdue periods
-5. Delete baseline entry from memory **only if** metric removal succeeds
-6. Delete baseline entry from database (non-blocking, logged on failure)
+5. Delete baseline entry from the poll-local map **only if** metric removal succeeds
+6. Delete baseline entry from the database (non-blocking, logged on failure)
 
 **Critical safeguard**: Baselines are retained if:
 
@@ -234,7 +234,7 @@ Validation errors (schema mismatches, type errors) are **not retried** as they i
 
 If stale provider cleanup encounters errors (database failures, missing provider info), the cleanup is skipped entirely to preserve metric baselines and prevent double-counting.
 
-Source: [`data-retention.service.ts` (`pollDataRetention`)](../../apps/backend/src/data-retention/data-retention.service.ts#L50)
+Source: [`data-retention.service.ts` (`pollDataRetention`)](../../apps/backend/src/data-retention/data-retention.service.ts)
 
 ## Architecture Diagram
 
@@ -265,7 +265,7 @@ flowchart TD
     CheckDeltas -->|No| PersistBaseline
     ResetBaseline --> PersistBaseline[Persist Baseline to DB]
     PersistBaseline --> CheckPersist{Persist<br/>Success?}
-    CheckPersist -->|Yes| UpdateBaseline[Update Baseline in Memory]
+    CheckPersist -->|Yes| UpdateBaseline[Update Poll-Local Baseline]
     UpdateBaseline --> CheckEmit{Positive<br/>Deltas?}
     CheckEmit -->|Yes| IncrementMetrics[Increment Prometheus Counters]
     CheckEmit -->|No| MoreBatches
@@ -280,7 +280,7 @@ flowchart TD
 
     Cleanup --> FetchStale[Fetch Stale Provider Info from DB]
     FetchStale --> RemoveMetrics[Remove Prometheus Metrics]
-    RemoveMetrics --> DeleteMemory[Delete Baseline from Memory]
+    RemoveMetrics --> DeleteMemory[Delete Baseline from Poll-Local Map]
     DeleteMemory --> DeleteDB[Delete Baseline from DB]
 
     SkipCleanup --> End[Complete]
@@ -320,7 +320,7 @@ Poll 1 (fresh start, no DB baseline):
 
 Poll 2:
   Subgraph: faulted=1005, success=9005
-  Memory baseline: 1000, 9000 → Period delta: 5, 5 (× 5 challenges/period)
+  Loaded baseline: 1000, 9000 → Period delta: 5, 5 (× 5 challenges/period)
   Emit: +25 faulted challenges, +25 success challenges
 
 --- SERVICE RESTARTS ---
@@ -332,7 +332,7 @@ Poll 3 (after restart):
 
 Poll 4:
   Subgraph: faulted=1008, success=9012
-  Memory baseline: 1005, 9005 → Period delta: 3, 7
+  Loaded baseline: 1005, 9005 → Period delta: 3, 7
   Emit: +15 faulted challenges, +35 success challenges
 ```
 


### PR DESCRIPTION
## What changed

Data retention polls now reload persisted baselines at the start of every run and treat Postgres as the shared source of truth across worker pods. Provider processing computes deltas without mutating local counter state; the service persists each new baseline first, then updates memory and increments `dataSetChallengeStatus` only after that provider write succeeds.

This fixes #517, where sequential `data_retention_poll` jobs could run on different worker pods and reuse stale process-local baselines, inflating summed Prometheus counters.

The data-retention docs now describe the cross-pod baseline lifecycle and persist-before-counter order.

## How to verify

- `pnpm -C apps/backend test src/data-retention/data-retention.service.spec.ts`
- `pnpm -C apps/backend typecheck`
- `pnpm -C apps/backend check:ci`

## Notes

Provider baseline writes still run in parallel within each batch. `data_retention_poll` is enqueued as a pg-boss global singleton by job type; this PR also skips overlapping `pollDataRetention()` calls inside one worker process.

I confirmed the new pod-alternation regression test fails against the old service with `[10, 10]` increments and passes on this branch with `[5, 5]`.