### PR TITLE
refactor: centralize data-set probe in DealService

### DIFF
--- a/apps/backend/src/deal/deal.service.spec.ts
+++ b/apps/backend/src/deal/deal.service.spec.ts
@@ -1252,6 +1252,132 @@ describe("DealService", () => {
     });
   });
 
+  describe("resolveDataSetMetadataForDeal", () => {
+    const providerInfo: PDPProviderEx = {
+      id: 101n,
+      serviceProvider: "0xprovider",
+      payee: "0x100",
+      name: "Test Provider",
+      description: "Test Provider",
+      isActive: true,
+      isApproved: true,
+      pdp: {
+        serviceURL: "service url",
+        minPieceSizeInBytes: 0n,
+        maxPieceSizeInBytes: 100n,
+        storagePricePerTibPerDay: 1n,
+        minProvingPeriodInEpochs: 1n,
+        location: "location",
+        paymentTokenAddress: "0x100",
+        ipniPiece: true,
+        ipniIpfs: true,
+      },
+    };
+
+    let probeSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      vi.spyOn(mockWalletSdkService, "getProviderInfo").mockReturnValue(providerInfo);
+      probeSpy = vi.spyOn(service, "getDataSetProvisioningStatus");
+    });
+
+    afterEach(() => {
+      probeSpy.mockRestore();
+      vi.spyOn(Math, "random").mockRestore();
+    });
+
+    it("returns undefined when minDataSets=1 and baseline is live", async () => {
+      (service as any).blockchainConfig.minNumDataSetsForChecks = 1;
+      probeSpy.mockResolvedValueOnce({ status: "live", dataSetId: 1n });
+
+      const result = await service.resolveDataSetMetadataForDeal("0xprovider");
+      expect(result).toBeUndefined();
+      expect(probeSpy).toHaveBeenCalledTimes(1);
+      const [, metadata] = probeSpy.mock.calls[0] ?? [];
+      expect(metadata).not.toHaveProperty("dealbotDS");
+    });
+
+    it("throws DealJobTerminatedDataSetError when baseline is terminated", async () => {
+      (service as any).blockchainConfig.minNumDataSetsForChecks = 1;
+      probeSpy.mockResolvedValueOnce({ status: "terminated", dataSetId: 42n });
+
+      await expect(service.resolveDataSetMetadataForDeal("0xprovider")).rejects.toBeInstanceOf(
+        DealJobTerminatedDataSetError,
+      );
+    });
+
+    it("uses indexed slot when live; does not probe baseline", async () => {
+      (service as any).blockchainConfig.minNumDataSetsForChecks = 3;
+      vi.spyOn(Math, "random").mockReturnValue(0.5); // → index 1
+      probeSpy.mockResolvedValueOnce({ status: "live", dataSetId: 7n });
+
+      const result = await service.resolveDataSetMetadataForDeal("0xprovider");
+      expect(result).toEqual({ dealbotDS: "1" });
+      expect(probeSpy).toHaveBeenCalledTimes(1);
+      const [, metadata] = probeSpy.mock.calls[0] ?? [];
+      expect(metadata).toMatchObject({ dealbotDS: "1" });
+    });
+
+    it("falls back to baseline when indexed slot is missing", async () => {
+      (service as any).blockchainConfig.minNumDataSetsForChecks = 3;
+      vi.spyOn(Math, "random").mockReturnValue(0.8); // → index 2
+      probeSpy
+        .mockResolvedValueOnce({ status: "missing" })
+        .mockResolvedValueOnce({ status: "live", dataSetId: 1n });
+
+      const result = await service.resolveDataSetMetadataForDeal("0xprovider");
+      expect(result).toBeUndefined();
+      expect(probeSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("falls back to baseline when indexed slot is terminated (does not throw)", async () => {
+      (service as any).blockchainConfig.minNumDataSetsForChecks = 3;
+      vi.spyOn(Math, "random").mockReturnValue(0.5); // → index 1
+      probeSpy
+        .mockResolvedValueOnce({ status: "terminated", dataSetId: 99n })
+        .mockResolvedValueOnce({ status: "live", dataSetId: 1n });
+
+      const result = await service.resolveDataSetMetadataForDeal("0xprovider");
+      expect(result).toBeUndefined();
+      expect(probeSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("falls back to baseline when indexed slot probe throws (non-abort)", async () => {
+      (service as any).blockchainConfig.minNumDataSetsForChecks = 3;
+      vi.spyOn(Math, "random").mockReturnValue(0.5);
+      probeSpy
+        .mockRejectedValueOnce(new Error("rpc failure"))
+        .mockResolvedValueOnce({ status: "live", dataSetId: 1n });
+
+      const result = await service.resolveDataSetMetadataForDeal("0xprovider");
+      expect(result).toBeUndefined();
+      expect(probeSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("falls back to baseline when index 0 is selected", async () => {
+      (service as any).blockchainConfig.minNumDataSetsForChecks = 3;
+      vi.spyOn(Math, "random").mockReturnValue(0); // → index 0
+      probeSpy.mockResolvedValueOnce({ status: "live", dataSetId: 1n });
+
+      const result = await service.resolveDataSetMetadataForDeal("0xprovider");
+      expect(result).toBeUndefined();
+      expect(probeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("propagates abort from indexed probe", async () => {
+      (service as any).blockchainConfig.minNumDataSetsForChecks = 3;
+      vi.spyOn(Math, "random").mockReturnValue(0.5);
+      const controller = new AbortController();
+      probeSpy.mockImplementationOnce(async () => {
+        controller.abort();
+        throw new Error("aborted");
+      });
+
+      await expect(service.resolveDataSetMetadataForDeal("0xprovider", controller.signal)).rejects.toThrow();
+      expect(probeSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("repairTerminatedDataSet", () => {
     beforeEach(() => {
       vi.spyOn(mockWalletSdkService, "getProviderInfo").mockReturnValue({ id: 1n, name: "sp" } as any);

--- a/apps/backend/src/deal/deal.service.spec.ts
+++ b/apps/backend/src/deal/deal.service.spec.ts
@@ -1318,50 +1318,18 @@ describe("DealService", () => {
       expect(metadata).toMatchObject({ dealbotDS: "1" });
     });
 
-    it("falls back to baseline when indexed slot is missing", async () => {
-      (service as any).blockchainConfig.minNumDataSetsForChecks = 3;
-      vi.spyOn(Math, "random").mockReturnValue(0.8); // → index 2
-      probeSpy
-        .mockResolvedValueOnce({ status: "missing" })
-        .mockResolvedValueOnce({ status: "live", dataSetId: 1n });
-
-      const result = await service.resolveDataSetMetadataForDeal("0xprovider");
-      expect(result).toBeUndefined();
-      expect(probeSpy).toHaveBeenCalledTimes(2);
-    });
-
-    it("falls back to baseline when indexed slot is terminated (does not throw)", async () => {
-      (service as any).blockchainConfig.minNumDataSetsForChecks = 3;
-      vi.spyOn(Math, "random").mockReturnValue(0.5); // → index 1
-      probeSpy
-        .mockResolvedValueOnce({ status: "terminated", dataSetId: 99n })
-        .mockResolvedValueOnce({ status: "live", dataSetId: 1n });
-
-      const result = await service.resolveDataSetMetadataForDeal("0xprovider");
-      expect(result).toBeUndefined();
-      expect(probeSpy).toHaveBeenCalledTimes(2);
-    });
-
-    it("falls back to baseline when indexed slot probe throws (non-abort)", async () => {
+    it.each([
+      ["missing", () => probeSpy.mockResolvedValueOnce({ status: "missing" })],
+      ["terminated", () => probeSpy.mockResolvedValueOnce({ status: "terminated", dataSetId: 99n })],
+      ["probe throws", () => probeSpy.mockRejectedValueOnce(new Error("rpc failure"))],
+    ])("falls back to baseline when indexed slot is %s", async (_label, setupIndexedProbe) => {
       (service as any).blockchainConfig.minNumDataSetsForChecks = 3;
       vi.spyOn(Math, "random").mockReturnValue(0.5);
-      probeSpy
-        .mockRejectedValueOnce(new Error("rpc failure"))
-        .mockResolvedValueOnce({ status: "live", dataSetId: 1n });
-
-      const result = await service.resolveDataSetMetadataForDeal("0xprovider");
-      expect(result).toBeUndefined();
-      expect(probeSpy).toHaveBeenCalledTimes(2);
-    });
-
-    it("falls back to baseline when index 0 is selected", async () => {
-      (service as any).blockchainConfig.minNumDataSetsForChecks = 3;
-      vi.spyOn(Math, "random").mockReturnValue(0); // → index 0
+      setupIndexedProbe();
       probeSpy.mockResolvedValueOnce({ status: "live", dataSetId: 1n });
 
       const result = await service.resolveDataSetMetadataForDeal("0xprovider");
       expect(result).toBeUndefined();
-      expect(probeSpy).toHaveBeenCalledTimes(1);
     });
 
     it("propagates abort from indexed probe", async () => {

--- a/apps/backend/src/deal/deal.service.ts
+++ b/apps/backend/src/deal/deal.service.ts
@@ -92,11 +92,17 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
     options: {
       existingDealId?: string;
       signal?: AbortSignal;
-      extraDataSetMetadata?: Record<string, string>;
       logContext?: ProviderJobContext;
     },
   ): Promise<Deal> {
     options.signal?.throwIfAborted();
+
+    const extraDataSetMetadata = await this.resolveDataSetMetadataForDeal(
+      pdpProvider.serviceProvider,
+      options.signal,
+      options.logContext,
+    );
+
     const { preprocessed, cleanup } = await this.prepareDealInput(options.signal, options.logContext);
 
     try {
@@ -109,12 +115,104 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
         uploadPayload,
         options.existingDealId,
         options.signal,
-        options.extraDataSetMetadata,
+        extraDataSetMetadata,
         options.logContext,
       );
     } finally {
       await cleanup();
     }
+  }
+
+  /**
+   * Pick which data-set slot this deal will target.
+   *
+   * Policy:
+   *   - If `minNumDataSetsForChecks > 1` and a random index > 0 is selected,
+   *     probe that slot first. If live, use it. If missing or terminated,
+   *     fall through to baseline (data_set_creation owns repair/provisioning).
+   *   - Probe baseline. If terminated, throw `DealJobTerminatedDataSetError`
+   *     (baseline is the fallback target; nothing else to try).
+   *   - Live or missing baseline → return `undefined` (use baseline slot).
+   *
+   * The post-`createContext` `isDataSetLive` guard inside `createDeal` covers
+   * the TOCTOU window between this probe and the upload's own `createContext`.
+   */
+  async resolveDataSetMetadataForDeal(
+    providerAddress: string,
+    signal?: AbortSignal,
+    logContext?: ProviderJobContext,
+  ): Promise<Record<string, string> | undefined> {
+    signal?.throwIfAborted();
+    const baseDataSetMetadata = this.getBaseDataSetMetadata();
+
+    const indexedMetadata = await this.tryIndexedDataSetSlot(providerAddress, baseDataSetMetadata, signal, logContext);
+    if (indexedMetadata !== undefined) return indexedMetadata;
+
+    try {
+      const baselineStatus = await this.getDataSetProvisioningStatus(providerAddress, baseDataSetMetadata, signal);
+      if (baselineStatus.status === "terminated") {
+        throw new DealJobTerminatedDataSetError(baselineStatus.dataSetId);
+      }
+    } catch (error) {
+      if (signal?.aborted) throw error;
+      if (error instanceof DealJobTerminatedDataSetError) throw error;
+      this.logger.warn({
+        ...logContext,
+        event: "deal_job_dataset_check_failed",
+        message: "Failed to verify baseline data set; proceeding to attempt deal",
+        error: toStructuredError(error),
+      });
+    }
+
+    return undefined;
+  }
+
+  private async tryIndexedDataSetSlot(
+    providerAddress: string,
+    baseDataSetMetadata: Record<string, string>,
+    signal: AbortSignal | undefined,
+    logContext: ProviderJobContext | undefined,
+  ): Promise<Record<string, string> | undefined> {
+    const minDataSets = this.blockchainConfig.minNumDataSetsForChecks;
+    if (minDataSets <= 1) return undefined;
+    const dsIndex = Math.floor(Math.random() * minDataSets);
+    if (dsIndex === 0) return undefined;
+
+    const dsIndexMetadata = { dealbotDS: String(dsIndex) };
+    try {
+      const status = await this.getDataSetProvisioningStatus(
+        providerAddress,
+        { ...baseDataSetMetadata, ...dsIndexMetadata },
+        signal,
+      );
+      if (status.status === "live") return dsIndexMetadata;
+      if (status.status === "terminated") {
+        this.logger.warn({
+          ...logContext,
+          event: "deal_job_dataset_index_terminated",
+          message: "Selected data set index is PDP-terminated; falling back to baseline",
+          dataSetIndex: dsIndex,
+          dataSetId: status.dataSetId.toString(),
+        });
+      } else {
+        this.logger.log({
+          ...logContext,
+          event: "deal_job_dataset_fallback",
+          message: "Data set not yet provisioned; falling back to default data set",
+          dataSetIndex: dsIndex,
+        });
+      }
+    } catch (error) {
+      if (signal?.aborted) throw error;
+      this.logger.warn({
+        ...logContext,
+        event: "deal_job_dataset_check_failed",
+        message: "Failed to verify data set: falling back to default data set",
+        dataSetIndex: dsIndex,
+        error: toStructuredError(error),
+      });
+    }
+    return undefined;
   }
 
   /**

--- a/apps/backend/src/deal/deal.service.ts
+++ b/apps/backend/src/deal/deal.service.ts
@@ -134,8 +134,9 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
    *     (baseline is the fallback target; nothing else to try).
    *   - Live or missing baseline → return `undefined` (use baseline slot).
    *
-   * The post-`createContext` `isDataSetLive` guard inside `createDeal` covers
-   * the TOCTOU window between this probe and the upload's own `createContext`.
+   * The post-`createContext` `isDataSetLive` guard inside `createDeal` runs on
+   * the exact `dataSetId` the upload will use, and is the safety net for any
+   * caller of `createDealForProvider` that did not run this probe first.
    */
   async resolveDataSetMetadataForDeal(
     providerAddress: string,

--- a/apps/backend/src/jobs/jobs.service.spec.ts
+++ b/apps/backend/src/jobs/jobs.service.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DealJobTerminatedDataSetError } from "../common/errors.js";
 import type { IConfig, ISpBlocklistConfig } from "../config/app.config.js";
 import { DATA_RETENTION_POLL_QUEUE, PROVIDERS_REFRESH_QUEUE, SP_WORK_QUEUE } from "./job-queues.js";
 import { JobsService } from "./jobs.service.js";
@@ -907,13 +908,11 @@ describe("JobsService schedule rows", () => {
     );
   });
 
-  it("deal job creates deal without metadata when minNumDataSetsForChecks is 1", async () => {
+  it("deal job delegates to createDealForProvider", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-01T12:00:00Z"));
     const dealService = {
       createDealForProvider: vi.fn(async () => ({})),
-      getBaseDataSetMetadata: vi.fn(() => ({ withIpniIndexing: "" })),
-      getDataSetProvisioningStatus: vi.fn(async () => ({ status: "live" as const, dataSetId: 1n })),
     };
 
     const walletSdkService = {
@@ -936,7 +935,9 @@ describe("JobsService schedule rows", () => {
     expect(dealService.createDealForProvider).toHaveBeenCalledTimes(1);
     expect(dealService.createDealForProvider).toHaveBeenCalledWith(
       expect.objectContaining({ serviceProvider: "0xaaa" }),
-      expect.objectContaining({ extraDataSetMetadata: undefined }),
+      expect.objectContaining({
+        logContext: expect.objectContaining({ providerAddress: "0xaaa", providerId: 1 }),
+      }),
     );
   });
 
@@ -945,8 +946,6 @@ describe("JobsService schedule rows", () => {
     vi.setSystemTime(new Date("2024-01-01T12:00:00Z"));
     const dealService = {
       createDealForProvider: vi.fn(async () => ({})),
-      getBaseDataSetMetadata: vi.fn(() => ({ withIpniIndexing: "" })),
-      getDataSetProvisioningStatus: vi.fn(async () => ({ status: "live" as const, dataSetId: 1n })),
     };
 
     const walletSdkService = {
@@ -977,119 +976,15 @@ describe("JobsService schedule rows", () => {
     expect(dealService.createDealForProvider).toHaveBeenCalledTimes(1);
   });
 
-  it("deal job passes dealbotDS metadata when selecting a provisioned data set index", async () => {
+  it("deal job maps DealJobTerminatedDataSetError to handler_result=error", async () => {
+    const completedCounter = metricsMocks.jobsCompletedCounter as unknown as { inc: ReturnType<typeof vi.fn> };
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-01T12:00:00Z"));
-    baseConfigValues = {
-      ...baseConfigValues,
-      blockchain: { ...baseConfigValues.blockchain, minNumDataSetsForChecks: 3 } as IConfig["blockchain"],
-    };
-    configService = {
-      get: vi.fn((key: keyof IConfig) => baseConfigValues[key]),
-    } as unknown as JobsServiceDeps[0];
 
     const dealService = {
-      createDealForProvider: vi.fn(async () => ({})),
-      getBaseDataSetMetadata: vi.fn(() => ({ dealbotDataSetVersion: "v1", withIpniIndexing: "" })),
-      getDataSetProvisioningStatus: vi.fn(async () => ({ status: "live" as const, dataSetId: 7n })),
-    };
-
-    const walletSdkService = {
-      getTestingProviders: vi.fn(() => [{ serviceProvider: "0xaaa" }]),
-      ensureWalletAllowances: vi.fn(),
-      loadProviders: vi.fn(),
-      getProviderInfo: vi.fn(() => ({ id: 1, name: "test-provider" })),
-    };
-
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
-
-    service = buildService({
-      configService,
-      dealService: dealService as unknown as ConstructorParameters<typeof JobsService>[3],
-      walletSdkService: walletSdkService as unknown as ConstructorParameters<typeof JobsService>[5],
-    });
-
-    await callPrivate(service, "handleDealJob", {
-      id: "job-deal-2",
-      data: { jobType: "deal", spAddress: "0xaaa", intervalSeconds: 60 },
-    });
-
-    expect(dealService.getDataSetProvisioningStatus).toHaveBeenCalledWith(
-      "0xaaa",
-      { dealbotDataSetVersion: "v1", withIpniIndexing: "", dealbotDS: "1" },
-      expect.any(AbortSignal),
-    );
-    expect(dealService.createDealForProvider).toHaveBeenCalledTimes(1);
-    expect(dealService.createDealForProvider).toHaveBeenCalledWith(
-      expect.objectContaining({ serviceProvider: "0xaaa" }),
-      expect.objectContaining({
-        extraDataSetMetadata: { dealbotDS: "1" },
+      createDealForProvider: vi.fn(async () => {
+        throw new DealJobTerminatedDataSetError(42n);
       }),
-    );
-
-    vi.spyOn(Math, "random").mockRestore();
-  });
-
-  it("deal job falls back to default data set when selecting an unprovisioned index", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2024-01-01T12:00:00Z"));
-    baseConfigValues = {
-      ...baseConfigValues,
-      blockchain: { ...baseConfigValues.blockchain, minNumDataSetsForChecks: 3 } as IConfig["blockchain"],
-    };
-    configService = {
-      get: vi.fn((key: keyof IConfig) => baseConfigValues[key]),
-    } as unknown as JobsServiceDeps[0];
-
-    const dealService = {
-      createDealForProvider: vi.fn(async () => ({})),
-      getBaseDataSetMetadata: vi.fn(() => ({ dealbotDataSetVersion: "v1" })),
-      getDataSetProvisioningStatus: vi.fn(async () => ({ status: "missing" as const })),
-    };
-
-    const walletSdkService = {
-      getTestingProviders: vi.fn(() => [{ serviceProvider: "0xaaa" }]),
-      ensureWalletAllowances: vi.fn(),
-      loadProviders: vi.fn(),
-      getProviderInfo: vi.fn(() => ({ id: 1, name: "test-provider" })),
-    };
-
-    vi.spyOn(Math, "random").mockReturnValue(0.8);
-
-    service = buildService({
-      configService,
-      dealService: dealService as unknown as ConstructorParameters<typeof JobsService>[3],
-      walletSdkService: walletSdkService as unknown as ConstructorParameters<typeof JobsService>[5],
-    });
-
-    await callPrivate(service, "handleDealJob", {
-      id: "job-deal-3",
-      data: { jobType: "deal", spAddress: "0xaaa", intervalSeconds: 60 },
-    });
-
-    expect(dealService.getDataSetProvisioningStatus).toHaveBeenCalledWith(
-      "0xaaa",
-      { dealbotDataSetVersion: "v1", dealbotDS: "2" },
-      expect.any(AbortSignal),
-    );
-    expect(dealService.createDealForProvider).toHaveBeenCalledTimes(1);
-    expect(dealService.createDealForProvider).toHaveBeenCalledWith(
-      expect.objectContaining({ serviceProvider: "0xaaa" }),
-      expect.objectContaining({ extraDataSetMetadata: undefined }),
-    );
-
-    vi.spyOn(Math, "random").mockRestore();
-  });
-
-  it("deal job fails with handler_result=error when baseline data set is PDP-terminated", async () => {
-    const completedCounter = metricsMocks.jobsCompletedCounter as unknown as { inc: ReturnType<typeof vi.fn> };
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2024-01-01T12:00:00Z"));
-
-    const dealService = {
-      createDealForProvider: vi.fn(async () => ({})),
-      getBaseDataSetMetadata: vi.fn(() => ({ withIpniIndexing: "" })),
-      getDataSetProvisioningStatus: vi.fn(async () => ({ status: "terminated" as const, dataSetId: 42n })),
     };
 
     const walletSdkService = {
@@ -1100,52 +995,6 @@ describe("JobsService schedule rows", () => {
     };
 
     service = buildService({
-      dealService: dealService as unknown as ConstructorParameters<typeof JobsService>[3],
-      walletSdkService: walletSdkService as unknown as ConstructorParameters<typeof JobsService>[5],
-    });
-
-    await callPrivate(service, "handleDealJob", {
-      id: "job-deal-terminated-baseline",
-      data: { jobType: "deal", spAddress: "0xaaa", intervalSeconds: 60 },
-    });
-
-    expect(dealService.createDealForProvider).not.toHaveBeenCalled();
-    expect(completedCounter.inc).toHaveBeenCalledWith({ job_type: "deal", handler_result: "error" });
-  });
-
-  it("deal job fails with handler_result=error when selected data set index is PDP-terminated", async () => {
-    const completedCounter = metricsMocks.jobsCompletedCounter as unknown as { inc: ReturnType<typeof vi.fn> };
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2024-01-01T12:00:00Z"));
-    baseConfigValues = {
-      ...baseConfigValues,
-      blockchain: { ...baseConfigValues.blockchain, minNumDataSetsForChecks: 3 } as IConfig["blockchain"],
-    };
-    configService = {
-      get: vi.fn((key: keyof IConfig) => baseConfigValues[key]),
-    } as unknown as JobsServiceDeps[0];
-
-    const dealService = {
-      createDealForProvider: vi.fn(async () => ({})),
-      getBaseDataSetMetadata: vi.fn(() => ({ dealbotDataSetVersion: "v1" })),
-      // First call (baseline) → live; second call (dsIndex) → terminated.
-      getDataSetProvisioningStatus: vi
-        .fn()
-        .mockResolvedValueOnce({ status: "live" as const, dataSetId: 1n })
-        .mockResolvedValueOnce({ status: "terminated" as const, dataSetId: 42n }),
-    };
-
-    const walletSdkService = {
-      getTestingProviders: vi.fn(() => [{ serviceProvider: "0xaaa" }]),
-      ensureWalletAllowances: vi.fn(),
-      loadProviders: vi.fn(),
-      getProviderInfo: vi.fn(() => ({ id: 1, name: "test-provider" })),
-    };
-
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
-
-    service = buildService({
-      configService,
       dealService: dealService as unknown as ConstructorParameters<typeof JobsService>[3],
       walletSdkService: walletSdkService as unknown as ConstructorParameters<typeof JobsService>[5],
     });
@@ -1155,112 +1004,8 @@ describe("JobsService schedule rows", () => {
       data: { jobType: "deal", spAddress: "0xaaa", intervalSeconds: 60 },
     });
 
-    expect(dealService.createDealForProvider).not.toHaveBeenCalled();
+    expect(dealService.createDealForProvider).toHaveBeenCalledTimes(1);
     expect(completedCounter.inc).toHaveBeenCalledWith({ job_type: "deal", handler_result: "error" });
-
-    vi.spyOn(Math, "random").mockRestore();
-  });
-
-  it("deal job falls back to default data set when data-set existence check throws", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2024-01-01T12:00:00Z"));
-    baseConfigValues = {
-      ...baseConfigValues,
-      blockchain: { ...baseConfigValues.blockchain, minNumDataSetsForChecks: 3 } as IConfig["blockchain"],
-    };
-    configService = {
-      get: vi.fn((key: keyof IConfig) => baseConfigValues[key]),
-    } as unknown as JobsServiceDeps[0];
-
-    const dealService = {
-      createDealForProvider: vi.fn(async () => ({})),
-      getBaseDataSetMetadata: vi.fn(() => ({ withIpniIndexing: "" })),
-      getDataSetProvisioningStatus: vi.fn(async () => {
-        throw new Error("lookup failed");
-      }),
-    };
-
-    const walletSdkService = {
-      getTestingProviders: vi.fn(() => [{ serviceProvider: "0xaaa" }]),
-      ensureWalletAllowances: vi.fn(),
-      loadProviders: vi.fn(),
-      getProviderInfo: vi.fn(() => ({ id: 1, name: "test-provider" })),
-    };
-
-    vi.spyOn(Math, "random").mockReturnValue(0.5);
-
-    service = buildService({
-      configService,
-      dealService: dealService as unknown as ConstructorParameters<typeof JobsService>[3],
-      walletSdkService: walletSdkService as unknown as ConstructorParameters<typeof JobsService>[5],
-    });
-
-    await callPrivate(service, "handleDealJob", {
-      id: "job-deal-4",
-      data: { jobType: "deal", spAddress: "0xaaa", intervalSeconds: 60 },
-    });
-
-    expect(dealService.createDealForProvider).toHaveBeenCalledWith(
-      expect.objectContaining({ serviceProvider: "0xaaa" }),
-      expect.objectContaining({ extraDataSetMetadata: undefined }),
-    );
-
-    vi.spyOn(Math, "random").mockRestore();
-  });
-
-  it("data storage job does not run data-storage check when data-set selection aborts", async () => {
-    const completedCounter = metricsMocks.jobsCompletedCounter as unknown as { inc: ReturnType<typeof vi.fn> };
-
-    baseConfigValues = {
-      ...baseConfigValues,
-      blockchain: { ...baseConfigValues.blockchain, minNumDataSetsForChecks: 3 } as IConfig["blockchain"],
-      jobs: {
-        ...baseConfigValues.jobs,
-        dealJobTimeoutSeconds: 1,
-      } as IConfig["jobs"],
-    };
-    configService = {
-      get: vi.fn((key: keyof IConfig) => baseConfigValues[key]),
-    } as unknown as JobsServiceDeps[0];
-
-    const dealService = {
-      createDealForProvider: vi.fn(async () => ({})),
-      getBaseDataSetMetadata: vi.fn(() => ({ dealbotDataSetVersion: "v1" })),
-      getDataSetProvisioningStatus: vi.fn(
-        async (_sp: string, _metadata: Record<string, string>, signal?: AbortSignal) => {
-          vi.advanceTimersByTime(120_000);
-          signal?.throwIfAborted();
-          return { status: "missing" as const };
-        },
-      ),
-    };
-
-    const walletSdkService = {
-      getTestingProviders: vi.fn(() => [{ serviceProvider: "0xaaa" }]),
-      ensureWalletAllowances: vi.fn(),
-      loadProviders: vi.fn(),
-      getProviderInfo: vi.fn(() => ({ id: 1, name: "test-provider" })),
-    };
-
-    vi.spyOn(Math, "random").mockReturnValue(0.8);
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2024-01-01T12:00:00Z"));
-
-    service = buildService({
-      configService,
-      dealService: dealService as unknown as ConstructorParameters<typeof JobsService>[3],
-      walletSdkService: walletSdkService as unknown as ConstructorParameters<typeof JobsService>[5],
-    });
-
-    await callPrivate(service, "handleDealJob", {
-      id: "job-deal-selection-abort",
-      data: { jobType: "deal", spAddress: "0xaaa", intervalSeconds: 60 },
-    });
-
-    expect(dealService.createDealForProvider).not.toHaveBeenCalled();
-    expect(completedCounter.inc).toHaveBeenCalledWith({ job_type: "deal", handler_result: "aborted" });
-
-    vi.spyOn(Math, "random").mockRestore();
   });
 
   it("data_set_creation job creates initial data set when minNumDataSetsForChecks is 1", async () => {

--- a/apps/backend/src/jobs/jobs.service.ts
+++ b/apps/backend/src/jobs/jobs.service.ts
@@ -473,89 +473,9 @@ export class JobsService implements OnModuleInit, OnApplicationShutdown {
           }
         }
 
-        // Probe data set status up front so upload prep is not spent on a
-        // PDP-terminated slot.
-        const minDataSets = this.configService.get("blockchain").minNumDataSetsForChecks;
-        const baseDataSetMetadata = this.dealService.getBaseDataSetMetadata();
-        let extraDataSetMetadata: Record<string, string> | undefined;
-
-        try {
-          const baselineStatus = await this.dealService.getDataSetProvisioningStatus(
-            spAddress,
-            baseDataSetMetadata,
-            abortController.signal,
-          );
-          if (baselineStatus.status === "terminated") {
-            throw new DealJobTerminatedDataSetError(baselineStatus.dataSetId);
-          }
-        } catch (error) {
-          if (abortController.signal.aborted) {
-            throw abortController.signal.reason;
-          }
-          if (error instanceof DealJobTerminatedDataSetError) {
-            throw error;
-          }
-          this.logger.warn({
-            ...logContext,
-            event: "deal_job_dataset_check_failed",
-            message: "Failed to verify baseline data set; proceeding to attempt deal",
-            error: toStructuredError(error),
-          });
-        }
-
-        if (minDataSets > 1) {
-          const dsIndex = Math.floor(Math.random() * minDataSets);
-          if (dsIndex > 0) {
-            const dsIndexMetadata = { dealbotDS: String(dsIndex) };
-            const expectedMetadata = { ...baseDataSetMetadata, ...dsIndexMetadata };
-            try {
-              const status = await this.dealService.getDataSetProvisioningStatus(
-                spAddress,
-                expectedMetadata,
-                abortController.signal,
-              );
-
-              if (status.status === "live") {
-                extraDataSetMetadata = dsIndexMetadata;
-              } else if (status.status === "terminated") {
-                throw new DealJobTerminatedDataSetError(status.dataSetId);
-              } else {
-                this.logger.log({
-                  ...logContext,
-                  event: "deal_job_dataset_fallback",
-                  message: "Data set not yet provisioned; falling back to default data set",
-                  dataSetIndex: dsIndex,
-                });
-              }
-            } catch (error) {
-              if (abortController.signal.aborted) {
-                throw abortController.signal.reason;
-              }
-              if (error instanceof DealJobTerminatedDataSetError) {
-                this.logger.warn({
-                  ...logContext,
-                  event: "deal_job_dataset_index_terminated",
-                  message: "Selected data set index is PDP-terminated",
-                  dataSetIndex: dsIndex,
-                  dataSetId: error.dataSetId.toString(),
-                });
-                throw error;
-              }
-              this.logger.warn({
-                ...logContext,
-                event: "deal_job_dataset_check_failed",
-                message: "Failed to verify data set: falling back to default data set",
-                dataSetIndex: dsIndex,
-                error: toStructuredError(error),
-              });
-            }
-          }
-        }
-
         abortController.signal.throwIfAborted();
         await this.dealService.createDealForProvider(provider, {
           signal: abortController.signal,
-          extraDataSetMetadata,
           logContext: {
             jobId: logContext.jobId,
             providerAddress: logContext.providerAddress,


### PR DESCRIPTION
## What changed

Lift the dsIndex selection + `getDataSetProvisioningStatus` probe out of `handleDealJob` into a new `DealService.resolveDataSetMetadataForDeal`, invoked from `createDealForProvider`. `handleDealJob` delegates to `createDealForProvider` and maps `DealJobTerminatedDataSetError` to `handler_result: "error"`. `triggerDeal` (dev-tools) inherits the same policy automatically.

Follow-up to #518 review feedback at https://github.com/FilOzone/dealbot/pull/518#pullrequestreview-4282036395.

### Behavior changes

- When `minNumDataSetsForChecks > 1` and the randomly selected indexed slot is PDP-terminated, the deal job falls back to the baseline slot instead of failing the whole job. The terminated index is logged (`deal_job_dataset_index_terminated`); `data_set_creation` still owns repair.
- Common case (`minDataSets > 1`, indexed slot live) drops from 2 `getDataSetProvisioningStatus` calls to 1.

### Why this differs from silent-cipher's exact suggestion

Silent-cipher also suggested removing the inner `isDataSetLive` guard inside `createDeal` (deal.service.ts:266-272). This PR keeps it. Reasoning:

- The upfront probe and `createDeal`'s own `createContext` are separated by `prepareDealInput` + `prepareUploadPayload` (CAR build, random data fetch, which takes seconds). PDP termination is async on-chain state; the window is wide enough to reproduce #379 without the guard.
- `triggerDeal` runs deal creation in a detached background promise, which widens the race further on the dev-tools path.
- The inner guard probes the exact `dataSetId` returned by the upload's own `createContext`, the only place that `dataSetId` is known. Upfront probes are advisory; the inner guard is the commit-time check.
- Cost is one `validateDataSet` RPC. Cost of failure is a wasted upload plus #379 recurrence. Asymmetric, favor the guard.

Four peer reviewers (Cursor, Claude, Codex, Gemini) ran on the proposed change. Three of four (Cursor, Claude, Codex) recommended keeping the inner guard and centralizing the upfront policy in `createDealForProvider`. This PR implements that consensus.

## How to verify

`pnpm test` from repo root. 345 tests pass (was 342 on #518; net +3 covering all `resolveDataSetMetadataForDeal` branches: minDataSets=1 live/terminated, indexed live, indexed missing fallback, indexed terminated fallback, indexed throw fallback, index 0, signal abort).

## Notes / risks

- `createDealForProvider`'s `extraDataSetMetadata` option is removed (caller no longer computes metadata). No external consumers exist outside `apps/backend`.
- Event `deal_job_dataset_index_terminated` is now emitted by `DealService` (was `JobsService`). Same event name and shape; dashboards keyed on the event name continue to work.