### PR TITLE
fix(retrieval): surface silent IPNI timeouts in logs

### DIFF
--- a/apps/backend/src/ipni/ipni-verification.service.spec.ts
+++ b/apps/backend/src/ipni/ipni-verification.service.spec.ts
@@ -117,6 +117,37 @@ describe("IpniVerificationService", () => {
     expect(result.rootCIDVerified).toBe(false);
   });
 
+  it("logs ipni_verification_timed_out even when external signal also aborted in the same tick", async () => {
+    const service = new IpniVerificationService();
+    const loggerError = vi.spyOn((service as unknown as { logger: { error: (m: object) => void } }).logger, "error");
+    const abortController = new AbortController();
+    waitForIpniProviderResultsMock.mockImplementation(
+      async (_cid: CID, options: { signal?: AbortSignal } | undefined) =>
+        await new Promise<boolean>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            "abort",
+            () => {
+              // Race: outer signal aborts before the catch handler runs.
+              abortController.abort(new Error("outer aborted in same tick"));
+              reject(new Error("inner aborted"));
+            },
+            { once: true },
+          );
+        }),
+    );
+
+    const result = await service.verify({
+      rootCid,
+      storageProvider: buildStorageProvider(),
+      timeoutMs: 20,
+      pollIntervalMs: 2_000,
+      signal: abortController.signal,
+    });
+
+    expect(result.rootCIDVerified).toBe(false);
+    expect(loggerError).toHaveBeenCalledWith(expect.objectContaining({ event: "ipni_verification_timed_out" }));
+  });
+
   it("is capped by the external deal signal", async () => {
     const service = new IpniVerificationService();
     const abortController = new AbortController();

--- a/apps/backend/src/ipni/ipni-verification.service.ts
+++ b/apps/backend/src/ipni/ipni-verification.service.ts
@@ -69,10 +69,10 @@ export class IpniVerificationService {
       expectedProviders,
       signal: verificationSignal,
     }).catch((error) => {
-      if (signal?.aborted) {
-        signal.throwIfAborted();
-      }
-      if (verificationSignal.aborted) {
+      // Inner-timeout check runs first so the `ipni_verification_timed_out` event
+      // fires even when the outer job signal aborts in the same tick. Otherwise
+      // the inner-timeout log path is unreachable whenever outer < inner.
+      if (timeoutSignal.aborted) {
         failureReason = `IPNI verification timed out after ${timeoutMs}ms`;
         this.logger.error({
           event: "ipni_verification_timed_out",
@@ -88,6 +88,9 @@ export class IpniVerificationService {
           maxAttempts,
         });
         return false;
+      }
+      if (signal?.aborted) {
+        signal.throwIfAborted();
       }
       const errorMessage = error instanceof Error ? error.message : String(error);
       failureReason = errorMessage;

--- a/apps/backend/src/retrieval/retrieval.service.spec.ts
+++ b/apps/backend/src/retrieval/retrieval.service.spec.ts
@@ -505,6 +505,25 @@ describe("RetrievalService parallel IPNI + transport", () => {
     expect(mockDiscoverabilityMetrics.recordStatus).toHaveBeenCalledWith(labels, "failure.timedout");
   });
 
+  it("logs retrieval_ipni_verification_timed_out when outer signal aborts and IPNI verify throws", async () => {
+    service = await createService();
+    setupCommonMocks();
+    const loggerWarn = vi.spyOn((service as unknown as { logger: { warn: (m: object) => void } }).logger, "warn");
+    const abortController = new AbortController();
+    mockIpniVerificationService.verify.mockImplementation(async () => {
+      abortController.abort(new Error("outer timeout"));
+      throw new Error("ipni aborted");
+    });
+    mockRetrievalAddonsService.testAllRetrievalMethods.mockResolvedValue(successfulTransport);
+
+    await service.performAllRetrievals(buildDealWithIpni(), abortController.signal);
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "retrieval_ipni_verification_timed_out" }),
+    );
+    expect(mockRetrievalMetrics.recordStatus).toHaveBeenCalledWith(labels, "failure.timedout");
+  });
+
   it("runs IPNI and transport concurrently", async () => {
     service = await createService();
     setupCommonMocks();

--- a/apps/backend/src/retrieval/retrieval.service.ts
+++ b/apps/backend/src/retrieval/retrieval.service.ts
@@ -473,6 +473,16 @@ export class RetrievalService {
     } catch (error) {
       if (signal?.aborted) {
         const failureStatus = "failure.timedout";
+        this.logger.warn({
+          event: "retrieval_ipni_verification_timed_out",
+          message: "Retrieval IPNI verification aborted by outer job timeout",
+          dealId,
+          providerId: provider.providerId,
+          providerName: provider.name,
+          providerAddress: provider.address,
+          ipfsRootCID: ipniContext.rootCid.toString(),
+          error: toStructuredError(error),
+        });
         this.discoverabilityMetrics.recordStatus(providerLabels, failureStatus);
         return { ok: false, failureStatus };
       }


### PR DESCRIPTION
## What changed

Two adjacent observability bugs left IPNI failures invisible whenever the outer pg-boss retrieval-job timeout fired:

1. **\`IpniVerificationService.verify\` check-order.** Catch checked \`signal?.aborted\` before \`verificationSignal.aborted\`. On a race where both signals had asserted by the time the catch handler ran, \`signal.throwIfAborted()\` re-threw before the \`ipni_verification_timed_out\` log could fire. The inner-timeout log path was effectively dead code whenever outer ≤ inner. Inner check now runs first so the log fires whenever the inner timer aborted.

2. **\`RetrievalService.verifyIpniForRetrieval\` silent abort.** The catch's signal-aborted branch returned a silent \`failure.timedout\` with no event log. Added \`retrieval_ipni_verification_timed_out\` so the retrieval-side caller records the abort.

Implements option C from #524. Stacks on #538.

## Files

- \`apps/backend/src/ipni/ipni-verification.service.ts\` — swap catch order so inner-timeout check wins same-tick races.
- \`apps/backend/src/retrieval/retrieval.service.ts\` — add \`retrieval_ipni_verification_timed_out\` log in the abort branch.
- \`apps/backend/src/ipni/ipni-verification.service.spec.ts\` — new test verifying \`ipni_verification_timed_out\` fires when both signals abort in the same tick.
- \`apps/backend/src/retrieval/retrieval.service.spec.ts\` — new test verifying \`retrieval_ipni_verification_timed_out\` fires when outer signal aborts and IPNI verify throws.

## How to verify

\`\`\`
pnpm --filter dealbot-backend typecheck
pnpm --filter dealbot-backend lint
pnpm --filter dealbot-backend test
\`\`\`

After deploy, staging logs should show \`ipni_verification_timed_out\` events 1:1 with \`retrievalStatus=failure.timedout\` deltas for SPs without IPNI advertisements (currently SP 5 Mongo2Stor, SP 17 superusey-calib in staging).

## Notes

Base branch is \`feat/retrieval-parallel-transport-counter\` (#538). Re-target to \`main\` after that PR merges.