### PR TITLE
fix: prevent concurrent insert race

### DIFF
--- a/apps/backend/src/deal-addons/deal-addons.service.spec.ts
+++ b/apps/backend/src/deal-addons/deal-addons.service.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Deal } from "../database/entities/deal.entity.js";
+import { ServiceType } from "../database/types.js";
+import { DealAddonsService } from "./deal-addons.service.js";
+import type { IDealAddon } from "./interfaces/deal-addon.interface.js";
+import type { IpniAddonStrategy } from "./strategies/ipni.strategy.js";
+import { AddonPriority } from "./types.js";
+
+describe("DealAddonsService", () => {
+  describe("handleStored", () => {
+    it("waits for already-started onStored work to reach its abort checkpoint", async () => {
+      const abortController = new AbortController();
+      let finishStartedWork!: () => void;
+      const startedWork = new Promise<void>((resolve) => {
+        finishStartedWork = resolve;
+      });
+
+      const deal = { id: "deal-1", spAddress: "0xprovider", metadata: {} } as Deal;
+      const ipniAddon = {
+        name: ServiceType.IPFS_PIN,
+        priority: AddonPriority.HIGH,
+        isApplicable: vi.fn(),
+        preprocessData: vi.fn(),
+        onStored: vi.fn(async (_deal: Deal, signal?: AbortSignal) => {
+          await startedWork;
+          signal?.throwIfAborted();
+        }),
+      } satisfies IDealAddon;
+      const service = new DealAddonsService(ipniAddon as unknown as IpniAddonStrategy);
+
+      let settled = false;
+      const handleStoredPromise = service
+        .handleStored(deal, [ServiceType.IPFS_PIN], abortController.signal)
+        .catch((error: unknown) => error)
+        .finally(() => {
+          settled = true;
+        });
+
+      abortController.abort(new Error("upload failed"));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(settled).toBe(false);
+
+      finishStartedWork();
+      await expect(handleStoredPromise).resolves.toEqual(expect.objectContaining({ message: "upload failed" }));
+      expect(settled).toBe(true);
+    });
+  });
+});

--- a/apps/backend/src/deal-addons/deal-addons.service.ts
+++ b/apps/backend/src/deal-addons/deal-addons.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger } from "@nestjs/common";
-import { awaitWithAbort } from "../common/abort-utils.js";
 import { type DealLogContext, ProviderJobContext, toStructuredError } from "../common/logging.js";
 import type { Deal } from "../database/entities/deal.entity.js";
 import type { DealMetadata } from "../database/types.js";
@@ -183,7 +182,7 @@ export class DealAddonsService {
       .map((addon) => addon!.onStored!(deal, signal, dealLogContext));
 
     try {
-      await awaitWithAbort(Promise.all(storedPromises), signal);
+      await Promise.all(storedPromises);
       this.logger.debug({
         ...dealLogContext,
         event: "addon_on_stored_completed",


### PR DESCRIPTION
## What
Removes awaitWithAbort from handleStored in DealAddonsService, replacing it with a plain await Promise.all(storedPromises). Also removes the now-unused awaitWithAbort import from deal-addons.service.ts.

## Why
### Root cause
When executeUpload throws after the "stored" event fires (e.g. a CommitError: Data set not found from an on-chain commit failure), the following race occurs:

1. The `"stored"` event spawns `handleStored(...)` as a detached promise.
2. Inside `handleStored`, `ipni.strategy.onStored` sets `ipniStatus = PENDING` and begins `await dealRepository.save(deal)` — an in-flight `INSERT` for the deal row.
3. `executeUpload` throws. createDeal's catch runs, then finally.
4. In finally, `addonAbortCtrl.abort()` fires, which causes `awaitWithAbort` inside `handleStored` to reject immediately — making the wrapper `onStoredAddons.promise` resolve to false almost instantly.
5. `await pending.catch(() => {})` returns, but the underlying `Promise.all(storedPromises)` is still running — specifically, the IPNI `dealRepository.save(deal)` is still in-flight on its Postgres connection.
6. `saveDeal` proceeds, calls `dealRepository.save(deal)`. TypeORM's `SubjectDatabaseEntityLoader` runs a `SELECT` for `deal.id`, finds no row (IPNI INSERT hasn't committed), decides `INSERT`, and submits it.
7. The IPNI INSERT commits first → saveDeal's INSERT hits `deals_pkey` unique constraint → `QueryFailedError` code `23505` → `save_deal_failed` warn log.

This is confirmed by production logs: `"stored"` → `CommitError` 56 ms later → `save_deal_failed` 1.6 s after that. The 1.6 s gap is PostgreSQL blocking saveDeal's INSERT waiting for the concurrent IPNI INSERT to commit.

### Why the signal doesn't help
`awaitWithAbort` races the inner promise against the signal — when the signal fires it rejects the outer awaiter but does not cancel the underlying DB call. The IPNI strategy does check `signal?.throwIfAborted()` (line 141 of `ipni.strategy.ts`), but only after `dealRepository.save(deal) `completes. So the abort terminates the awaiting, not the execution.

## Fix
Replacing `awaitWithAbort(Promise.all(storedPromises), signal)` with `Promise.all(storedPromises)` ensures `handleStored` only returns once every addon's in-flight DB write has committed. By the time `saveDeal` runs in `finally`, there is no concurrent INSERT — TypeORM's SELECT finds the committed row and issues an `UPDATE` instead.

Abort behaviour is fully preserved: each addon receives `signal` and calls `signal?.throwIfAborted()` at its own safe checkpoints (after saves, not during them). `Promise.all` will still reject with the abort error, handleStored's catch re-throws, and the `finally` path proceeds normally.

## Validation

I was unable to reliably reproduce this race locally, so the fix is based on analysis of the production logs and the execution ordering described above.

Closes #520 