### PR TITLE
chore: ban nested ternaries via biome

### DIFF
--- a/apps/backend/src/common/logging.ts
+++ b/apps/backend/src/common/logging.ts
@@ -16,6 +16,22 @@ export type StructuredError = {
   cause?: StructuredError;
 };
 
+/**
+ * Redacted flat message from an unknown error. Prefers the immediate
+ * `cause.message` over the outer `message` when a cause is present, because
+ * outer wrappers in this codebase tend to carry high-cardinality context (e.g.
+ * deal IDs) that defeats group-by aggregation in BetterStack/Grafana
+ * dashboards. See PR #491 / issue #473 for the original rationale.
+ *
+ * Pair with `toStructuredError` in the same log line so the full chain remains
+ * available for deep debugging while this flat field stays aggregable.
+ */
+export function getErrorMessage(error: unknown): string {
+  const structured = toStructuredError(error);
+  const cause = structured.cause;
+  return cause?.type === "error" && cause.message ? cause.message : structured.message;
+}
+
 export function toJsonSafe(value: unknown): unknown {
   try {
     return JSON.parse(

--- a/apps/backend/src/deal-addons/strategies/ipni.strategy.ts
+++ b/apps/backend/src/deal-addons/strategies/ipni.strategy.ts
@@ -7,7 +7,7 @@ import type { StorageProvider } from "src/database/entities/storage-provider.ent
 import type { Repository } from "typeorm";
 import { delay } from "../../common/abort-utils.js";
 import { buildUnixfsCar } from "../../common/car-utils.js";
-import { type DealLogContext, toStructuredError } from "../../common/logging.js";
+import { type DealLogContext, getErrorMessage, toStructuredError } from "../../common/logging.js";
 import type { IConfig } from "../../config/app.config.js";
 import { Deal } from "../../database/entities/deal.entity.js";
 import type { DealMetadata, IpniMetadata } from "../../database/types.js";
@@ -262,12 +262,7 @@ export class IpniAddonStrategy implements IDealAddon<IpniMetadata> {
           ...dealLogContext,
           event: "ipni_tracking_failed",
           message: "IPNI tracking failed",
-          failureReason:
-            error instanceof Error
-              ? error.cause instanceof Error
-                ? error.cause.message
-                : error.message
-              : String(error),
+          failureReason: getErrorMessage(error),
           error: toStructuredError(error),
         });
       } catch (saveError) {

--- a/apps/web/src/pages/Landing.tsx
+++ b/apps/web/src/pages/Landing.tsx
@@ -54,18 +54,19 @@ const getConfig = (network: Network | null) => {
   const runtimeConfig = typeof window === "undefined" ? undefined : window.__DEALBOT_CONFIG__;
 
   const dashboardUrl = getConfigUrl(runtimeConfig?.DASHBOARD_URL, import.meta.env.VITE_DASHBOARD_URL);
-  const approvedSpDashboardUrl =
-    network === "mainnet"
-      ? getConfigUrl(
-          runtimeConfig?.APPROVED_SP_DASHBOARD_URL_MAINNET,
-          import.meta.env.VITE_APPROVED_SP_DASHBOARD_URL_MAINNET,
-        )
-      : network === "calibration"
-        ? getConfigUrl(
-            runtimeConfig?.APPROVED_SP_DASHBOARD_URL_CALIBRATION,
-            import.meta.env.VITE_APPROVED_SP_DASHBOARD_URL_CALIBRATION,
-          )
-        : { safe: "", isInvalid: false };
+  const approvedSpSources: Record<Network, { runtime?: string; build?: string }> = {
+    mainnet: {
+      runtime: runtimeConfig?.APPROVED_SP_DASHBOARD_URL_MAINNET,
+      build: import.meta.env.VITE_APPROVED_SP_DASHBOARD_URL_MAINNET,
+    },
+    calibration: {
+      runtime: runtimeConfig?.APPROVED_SP_DASHBOARD_URL_CALIBRATION,
+      build: import.meta.env.VITE_APPROVED_SP_DASHBOARD_URL_CALIBRATION,
+    },
+  };
+  const approvedSpDashboardUrl = network
+    ? getConfigUrl(approvedSpSources[network].runtime, approvedSpSources[network].build)
+    : { safe: "", isInvalid: false };
   const logsUrl = getConfigUrl(runtimeConfig?.LOGS_URL, import.meta.env.VITE_LOGS_URL);
 
   return {

--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,8 @@
         "noExplicitAny": "off"
       },
       "style": {
-        "noNonNullAssertion": "off"
+        "noNonNullAssertion": "off",
+        "noNestedTernary": "error"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Enable Biome `style/noNestedTernary: error` repo-wide so nested ternaries fail CI.
- Fix the two existing violations:
  - `apps/web/src/pages/Landing.tsx`: replace nested ternary picking `approvedSpDashboardUrl` by network with a `Record<Network, ...>` lookup (gains compile-time exhaustiveness if `Network` grows).
  - `apps/backend/src/deal-addons/strategies/ipni.strategy.ts`: replace inline nested ternary on `failureReason` with a new `getErrorMessage` helper.
- Add `getErrorMessage(error: unknown): string` in `apps/backend/src/common/logging.ts`. Derives from `toStructuredError` (so redaction is inherited) and prefers `cause.message` over outer `message` when the cause is a real `Error` — preserves PR #491 / issue #473 intent of keeping `failureReason` aggregable in BetterStack/Grafana (no high-cardinality deal IDs in the flat field). Guards against non-Error causes leaking `"Non-Error thrown"`.

Peer-reviewed in three rounds via Claude, Cursor, and Gemini agents; consensus approved after the cause-preferred semantics were restored and the `cause.type === "error"` guard added.

## Test plan
- [x] `pnpm lint:check` — passes (the only remaining warning is in an untracked scratch file).
- [x] `pnpm build` (apps/backend) — passes.
- [x] `pnpm typecheck` (apps/web) — passes.
- [x] `pnpm vitest run src/common/logging.spec.ts src/deal-addons/strategies/ipni.strategy.spec.ts` — 23/23 pass.
- [ ] Post-merge: confirm BetterStack `WHERE event = 'ipni_tracking_failed' GROUP BY failureReason` still buckets cleanly (no deal-ID prefix regression).