### PR TITLE
fix(jobs): defer terminate to operator when payer is multisig

### DIFF
--- a/apps/backend/src/common/errors.ts
+++ b/apps/backend/src/common/errors.ts
@@ -23,6 +23,35 @@ export class DealJobTerminatedDataSetError extends Error {
 }
 
 /**
+ * Thrown by repairTerminatedDataSet when the dealbot wallet is a contract
+ * (Safe multisig) and the dataset still needs to be terminated on-chain.
+ * Dealbot's session-key signer is neither payer nor payee, so any direct
+ * terminateService call reverts with CallerNotPayerOrPayee. An operator
+ * must submit the termination via Safe (see https://github.com/FilOzone/dealbot/issues/545
+ * for the pattern). Once pdpEndEpoch is set on FWSS, the existing
+ * already-terminated branch in repairTerminatedDataSet runs the DB cleanup
+ * automatically.
+ *
+ * Tracking: https://github.com/FilOzone/dealbot/issues/546
+ */
+export class DataSetTerminateRequiresOperatorError extends Error {
+  readonly name = "DataSetTerminateRequiresOperatorError";
+
+  constructor(
+    public readonly dataSetId: bigint,
+    public readonly providerAddress: string,
+    public readonly payerAddress: string,
+  ) {
+    super(
+      `Data set ${dataSetId.toString()} on provider ${providerAddress} cannot be auto-terminated; payer ${payerAddress} is a contract. Operator must submit terminateService via Safe.`,
+    );
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, DataSetTerminateRequiresOperatorError);
+    }
+  }
+}
+
+/**
  * Custom error class for retrieval failures with HTTP context
  * Provides structured information about failed HTTP requests
  */

--- a/apps/backend/src/deal/deal.service.ts
+++ b/apps/backend/src/deal/deal.service.ts
@@ -10,7 +10,7 @@ import type { Repository } from "typeorm";
 import { ClickhouseService } from "../clickhouse/clickhouse.service.js";
 import { awaitWithAbort } from "../common/abort-utils.js";
 import { buildUnixfsCar } from "../common/car-utils.js";
-import { DealJobTerminatedDataSetError } from "../common/errors.js";
+import { DataSetTerminateRequiresOperatorError, DealJobTerminatedDataSetError } from "../common/errors.js";
 import { createFilecoinPinLogger } from "../common/filecoin-pin-logger.js";
 import {
   type DealLogContext,
@@ -852,6 +852,14 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
         pdpEndEpoch: pdpEndEpoch.toString(),
       });
     } else {
+      // Session-key + contract-payer (Safe multisig) mode cannot auto-terminate.
+      // FWSS.terminateService gates on msg.sender ∈ {payer, payee}, and our
+      // signer is the session-key EOA — not the payer.
+      // See https://github.com/FilOzone/dealbot/issues/546
+      if (this.blockchainConfig.sessionKeyPrivateKey) {
+        const payerAddress = existing?.payer ?? this.blockchainConfig.walletAddress ?? "";
+        throw new DataSetTerminateRequiresOperatorError(dataSetId, providerAddress, payerAddress);
+      }
       let txHash: `0x${string}` | undefined;
       try {
         txHash = await awaitWithAbort(synapse.storage.terminateDataSet({ dataSetId }), signal);

--- a/apps/backend/src/jobs/data-set-creation.handler.ts
+++ b/apps/backend/src/jobs/data-set-creation.handler.ts
@@ -1,4 +1,5 @@
 import type { Logger } from "@nestjs/common";
+import { DataSetTerminateRequiresOperatorError } from "../common/errors.js";
 import type { DataSetLogContext, ProviderJobContext } from "../common/logging.js";
 import type { DealService } from "../deal/deal.service.js";
 
@@ -59,14 +60,32 @@ export async function provisionNextMissingDataSet(
         message: "Detected PDP-terminated dataset; running repair",
         dataSetId: status.dataSetId.toString(),
       });
-      const result = await dealService.repairTerminatedDataSet(spAddress, status.dataSetId, signal);
-      logger.log({
-        ...logContext,
-        event: "data_set_repair_completed",
-        message: "Repaired terminated dataset; deferring replacement to next tick",
-        dataSetId: status.dataSetId.toString(),
-        dealsAffected: result.dealsAffected,
-      });
+      try {
+        const result = await dealService.repairTerminatedDataSet(spAddress, status.dataSetId, signal);
+        logger.log({
+          ...logContext,
+          event: "data_set_repair_completed",
+          message: "Repaired terminated dataset; deferring replacement to next tick",
+          dataSetId: status.dataSetId.toString(),
+          dealsAffected: result.dealsAffected,
+        });
+      } catch (error) {
+        if (error instanceof DataSetTerminateRequiresOperatorError) {
+          // Multisig payer cannot be auto-terminated; surface for operator
+          // action via Safe Transaction Builder.
+          // Tracking: https://github.com/FilOzone/dealbot/issues/546
+          logger.warn({
+            ...logContext,
+            event: "dataset_terminate_operator_action_required",
+            message:
+              "Dataset is PDP-terminated and the payer is a Safe multisig; operator must submit terminateService via Safe (see https://github.com/FilOzone/dealbot/issues/546)",
+            dataSetId: error.dataSetId.toString(),
+            payerAddress: error.payerAddress,
+          });
+          return;
+        }
+        throw error;
+      }
       return;
     }
 


### PR DESCRIPTION
## What changed

In session-key + multisig payer mode, `repairTerminatedDataSet` now throws a typed `DataSetTerminateRequiresOperatorError` instead of calling `synapse.storage.terminateDataSet`. The `data_set_creation` handler catches the typed error and emits `dataset_terminate_operator_action_required` so the operator can submit `terminateService` via Safe (as we did in #545).

The existing already-terminated branch in `repairTerminatedDataSet` is unchanged. Once an operator's Safe batch lands and FWSS reports `pdpEndEpoch != 0`, the next tick marks the affected `Deal` rows `cleaned_up=true` automatically.

EOA-mode behavior is unchanged.

## Why

`FWSS.terminateService` gates on `msg.sender ∈ {payer, payee}`. Our session-key EOA is neither, so any direct call would revert with `CallerNotPayerOrPayee` on-chain. Pre-flight simulation also fails today because Lotus rejects `eth_call` with `from` set to a contract address (lotus#13470 still open), and `apps/backend/src/common/synapse-factory.ts:safeReadTransport` strips `from` to work around that.

Full context: https://github.com/FilOzone/dealbot/issues/546

## How to verify

`pnpm test` from the repo root (362 tests pass).

Manual: in staging, after this lands, a `dataset_terminated_detected` event for a known-terminated dataset is now followed by `dataset_terminate_operator_action_required` (with `payerAddress` in the log) instead of failing on `CallerNotPayerOrPayee`. After the operator runs a Safe batch like #545, the next `data_set_creation` tick logs `dataset_already_terminated` + `dataset_terminated_repaired` and marks the corresponding `Deal` rows `cleaned_up=true`.

## Notes / risks

- Draft. No new tests yet for the new branch.
- Once synapse-sdk + FWSS land the EIP-712 session-key-signed termination path (FilOzone/synapse-sdk#796 + the contract-side PR), this guard can be removed.

Refs:
- #546 root cause + tracker
- #545 manual cleanup for provider 24
- #518 `data_set_creation` repair handler
- #419 `safeReadTransport` workaround
- filecoin-project/lotus#13470