### PR TITLE
fix(session-key): register TerminateService permission

### DIFF
--- a/apps/backend/scripts/create-session-key-safe.mjs
+++ b/apps/backend/scripts/create-session-key-safe.mjs
@@ -22,12 +22,10 @@ import { calibration, mainnet } from "@filoz/synapse-core/chains";
 import {
   AddPiecesPermission,
   CreateDataSetPermission,
-  DefaultFwssPermissions,
-  DeleteDataSetPermission,
   loginCall,
   SchedulePieceRemovalsPermission,
 } from "@filoz/synapse-core/session-key";
-import { decodeFunctionData, encodeFunctionData } from "viem";
+import { decodeFunctionData, encodeFunctionData, keccak256, stringToHex } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 
 // Parse CLI args
@@ -45,12 +43,20 @@ const chain = networkName === "mainnet" ? mainnet : calibration;
 const sessionAccount = privateKeyToAccount(sessionPrivateKey);
 const expiresAt = BigInt(Math.floor(Date.now() / 1000) + expiryDays * 24 * 60 * 60);
 const expiryDate = new Date(Number(expiresAt) * 1000);
+// TODO: Import TerminateServicePermission and DefaultFwssPermissions after DealBot upgrades to a Synapse SDK release that includes them.
+const TerminateServicePermission = keccak256(stringToHex("TerminateService(uint256 dataSetId)"));
+const DealBotFwssPermissions = [
+  CreateDataSetPermission,
+  AddPiecesPermission,
+  SchedulePieceRemovalsPermission,
+  TerminateServicePermission,
+];
 
 // Use the SDK's loginCall to get the exact ABI and args
 const call = loginCall({
   chain,
   address: sessionAccount.address,
-  permissions: DefaultFwssPermissions,
+  permissions: DealBotFwssPermissions,
   expiresAt,
   origin: "dealbot",
 });
@@ -73,7 +79,7 @@ const permissionLabels = {
   [CreateDataSetPermission]: "CreateDataSet",
   [AddPiecesPermission]: "AddPieces",
   [SchedulePieceRemovalsPermission]: "SchedulePieceRemovals",
-  [DeleteDataSetPermission]: "DeleteDataSet",
+  [TerminateServicePermission]: "TerminateService",
 };
 
 // Output
@@ -85,7 +91,7 @@ console.log(`Expiry:             ${expiryDate.toISOString()} (${expiryDays} days
 console.log(`Origin:             dealbot`);
 console.log();
 console.log("--- Permissions ---");
-for (const hash of DefaultFwssPermissions) {
+for (const hash of DealBotFwssPermissions) {
   console.log(`  ${permissionLabels[hash] || "Unknown"}: ${hash}`);
 }
 console.log();

--- a/apps/backend/scripts/create-session-key-safe.mjs
+++ b/apps/backend/scripts/create-session-key-safe.mjs
@@ -22,6 +22,8 @@ import { calibration, mainnet } from "@filoz/synapse-core/chains";
 import {
   AddPiecesPermission,
   CreateDataSetPermission,
+  DefaultFwssPermissions,
+  DeleteDataSetPermission,
   loginCall,
   SchedulePieceRemovalsPermission,
 } from "@filoz/synapse-core/session-key";
@@ -43,14 +45,11 @@ const chain = networkName === "mainnet" ? mainnet : calibration;
 const sessionAccount = privateKeyToAccount(sessionPrivateKey);
 const expiresAt = BigInt(Math.floor(Date.now() / 1000) + expiryDays * 24 * 60 * 60);
 const expiryDate = new Date(Number(expiresAt) * 1000);
-// TODO: Import TerminateServicePermission and DefaultFwssPermissions after DealBot upgrades to a Synapse SDK release that includes them.
+// TODO: import TerminateServicePermission from @filoz/synapse-core/session-key once it is exported there.
 const TerminateServicePermission = keccak256(stringToHex("TerminateService(uint256 dataSetId)"));
-const DealBotFwssPermissions = [
-  CreateDataSetPermission,
-  AddPiecesPermission,
-  SchedulePieceRemovalsPermission,
-  TerminateServicePermission,
-];
+// Backend rejects session keys missing any permission in SessionKey.DefaultFwssPermissions, so register
+// a superset: the defaults plus TerminateService. Extra permissions on the registry are accepted.
+const DealBotFwssPermissions = Array.from(new Set([...DefaultFwssPermissions, TerminateServicePermission]));
 
 // Use the SDK's loginCall to get the exact ABI and args
 const call = loginCall({
@@ -79,6 +78,7 @@ const permissionLabels = {
   [CreateDataSetPermission]: "CreateDataSet",
   [AddPiecesPermission]: "AddPieces",
   [SchedulePieceRemovalsPermission]: "SchedulePieceRemovals",
+  [DeleteDataSetPermission]: "DeleteDataSet",
   [TerminateServicePermission]: "TerminateService",
 };
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -409,7 +409,7 @@ WALLET_ADDRESS=0x1234567890abcdef1234567890abcdef12345678
 - **Required**: No
 - **Security**: **HIGHLY SENSITIVE** - Treat like `WALLET_PRIVATE_KEY`
 
-**Role**: When set, DealBot uses session key authentication. The session key must be registered on the SessionKeyRegistry contract from the `WALLET_ADDRESS` (typically a Safe multisig). Storage operations (create dataset, add pieces) are signed with this key instead of `WALLET_PRIVATE_KEY`.
+**Role**: When set, DealBot uses session key authentication. The session key must be registered on the SessionKeyRegistry contract from the `WALLET_ADDRESS` (typically a Safe multisig). Scoped storage operations are signed with this key instead of `WALLET_PRIVATE_KEY`.
 
 Session keys are scoped (only storage operations, not deposits or withdrawals) and time-limited (expiry set during registration). See [runbooks/wallet-and-session-keys.md](runbooks/wallet-and-session-keys.md) for the full setup process.
 

--- a/docs/runbooks/wallet-and-session-keys.md
+++ b/docs/runbooks/wallet-and-session-keys.md
@@ -22,7 +22,7 @@ DealBot uses a Safe multisig wallet with a session key for delegated signing. Th
 ## Overview
 
 - **Multisig wallet**: A Safe (safe.filecoin.io) 2-of-N multisig that owns the funds and datasets. Requires multiple signers for any direct wallet operation (deposits, operator approvals, etc.).
-- **Session key**: A regular Ethereum keypair registered on the SessionKeyRegistry contract with scoped permissions. DealBot uses this key for day-to-day operations (creating datasets, adding pieces) without needing multisig approval for each transaction.
+- **Session key**: A regular Ethereum keypair registered on the SessionKeyRegistry contract with scoped permissions. DealBot uses this key for day-to-day storage operations without needing multisig approval for each transaction.
 
 Multisig addresses and signers are documented in the [FOC Operational Excellence](https://www.notion.so/filecoindev/FOC-Operational-Excellence-2b7dc41950c1802aa432fff8ecb801cc#2fddc41950c180749b96e4ddc0fb6aaf) Notion page. The Safe UI is at [safe.filecoin.io](https://safe.filecoin.io/).
 
@@ -76,7 +76,7 @@ node scripts/create-session-key-safe.mjs \
 
 The script outputs:
 1. The session key address and private key
-2. Permission hashes being registered (CreateDataSet, AddPieces, SchedulePieceRemovals, DeleteDataSet)
+2. Permission hashes being registered (CreateDataSet, AddPieces, SchedulePieceRemovals, TerminateService)
 3. Safe transaction details: target contract address and ABI-encoded calldata
 4. Verification: the decoded calldata for human review before submission
 5. The `SESSION_KEY_PRIVATE_KEY` env var value for deployment
@@ -136,7 +136,7 @@ Monitor expiry dates. A session key that expires while DealBot is running will c
 
 ## Payment Setup
 
-Session keys can only perform scoped storage operations (create datasets, add pieces, schedule removals). They cannot:
+Session keys can only perform scoped storage operations (create datasets, add pieces, schedule removals, terminate service). They cannot:
 
 - Deposit USDFC into Filecoin Pay
 - Approve FWSS as an operator

--- a/docs/runbooks/wallet-and-session-keys.md
+++ b/docs/runbooks/wallet-and-session-keys.md
@@ -76,7 +76,7 @@ node scripts/create-session-key-safe.mjs \
 
 The script outputs:
 1. The session key address and private key
-2. Permission hashes being registered (CreateDataSet, AddPieces, SchedulePieceRemovals, TerminateService)
+2. Permission hashes being registered (CreateDataSet, AddPieces, SchedulePieceRemovals, DeleteDataSet, TerminateService)
 3. Safe transaction details: target contract address and ABI-encoded calldata
 4. Verification: the decoded calldata for human review before submission
 5. The `SESSION_KEY_PRIVATE_KEY` env var value for deployment


### PR DESCRIPTION
This is in preparation for https://github.com/FilOzone/synapse-sdk/pull/796, I've not relied on the Synapse dependency so this could be done separate to a Synapse upgrade if we want; or this could sit here and be used for the Synapse upgrade when we get a 0.42 and fix up the TODO. But the script in here is used to make the session key multisig, so it might be good to just merge this, make the new session key and sign it into the chain and then have that ready for the Synapse 0.42 upgrade deploy.

Another option in this PR is to include both `TerminateService` and `DeleteDataSet` in the same session key and then it can be deployed now and be future-proof later. It won't hurt at all having more permissions than needed, it'll just be redundant afterwards. To do that we'd just add a `const DeleteDataSetPermission = keccak256(stringToHex("DeleteDataSet(uint256 dataSetId)"));` as well as the new terminate one and add that to the list.

@SgtPooki whaddya reckon?