### PR TITLE
docs: refresh release + infra docs for GA state

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![NestJS](https://img.shields.io/badge/nestjs-11.x-red.svg)](https://nestjs.com)
 [![React](https://img.shields.io/badge/react-19.x-blue.svg)](https://react.dev)
 
-An intelligent automation system for creating and monitoring PDP deals on the Filecoin network. Features automated deal creation, retrieval performance testing, comprehensive metrics tracking, and a modern web dashboard.
+An intelligent automation system for creating and monitoring PDP deals on the Filecoin network. Features automated deal creation, retrieval performance testing, detailed metrics tracking, and a modern web dashboard.
 
 ## Features
 
@@ -46,7 +46,7 @@ Frontend docs: [apps/web/README.md](apps/web/README.md)
 
 ## Developer Docs
 
-- [docs/environment-variables.md](docs/environment-variables.md) - Comprehensive environment variables reference
+- [docs/environment-variables.md](docs/environment-variables.md) - Full environment variables reference
 - [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) - Local Kubernetes development (Kind + Kustomize)
 - [docs/deployment.md](docs/deployment.md) - Container images, Kustomize manifests, runtime topology
 - [docs/infra.md](docs/infra.md) - Ingress, egress, persistence, secrets, observability expectations

--- a/README.md
+++ b/README.md
@@ -29,12 +29,11 @@ dealbot/
 ├── apps/
 │   ├── backend/      # NestJS API server (Port 8080)
 │   │   ├── src/
-│   │   │   ├── deal/            # Deal creation and management
-│   │   │   ├── retrieval/       # Storage retrieval testing
-│   │   │   ├── metrics/         # Performance metrics and analytics
-│   │   │   ├── jobs/            # pg-boss scheduling + workers
-│   │   │   ├── scheduler/       # Automated task scheduling
-│   │   │   └── wallet-sdk/      # Wallet and contract operations
+│   │   │   ├── deal/                # Deal creation and management
+│   │   │   ├── retrieval/           # Storage retrieval testing
+│   │   │   ├── metrics-prometheus/  # Prometheus instrumentation
+│   │   │   ├── jobs/                # pg-boss scheduler + workers
+│   │   │   └── wallet-sdk/          # Wallet and contract operations
 │   │   └── README.md     # Backend-specific documentation
 │   └── web/          # React + Vite dashboard (Port 5173)
 │       ├── src/

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Frontend docs: [apps/web/README.md](apps/web/README.md)
 
 - [docs/environment-variables.md](docs/environment-variables.md) - Comprehensive environment variables reference
 - [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) - Local Kubernetes development (Kind + Kustomize)
-- [docs/infra.md](docs/infra.md) - Integration with FilOzone/infra
+- [docs/deployment.md](docs/deployment.md) - Container images, Kustomize manifests, runtime topology
+- [docs/infra.md](docs/infra.md) - Ingress, egress, persistence, secrets, observability expectations
 - [docs/architecture.md](docs/architecture.md) - System architecture, component responsibilities, and data stores
 - [docs/production-operations.md](docs/production-operations.md) - Links to operational docs (infra runbook, Notion tracker)
 - [docs/release-process.md](docs/release-process.md) - Release pipeline overview

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,20 +13,17 @@ graph TD
     ApiServices --> Wallet["Filecoin RPC / Contracts"]
     Jobs["Jobs Module (pg-boss scheduler + workers)"] --> ApiServices
     Jobs --> Db
-    ApiServices --> Metrics["Prometheus /metrics"]
-    Jobs --> Metrics
 ```
 
 ## Component Responsibilities
 
-- [Web UI](../apps/web): React/Vite dashboard served by a Caddy wrapper (static hosting plus `/api` and `/metrics` reverse proxy).
+- [Web UI](../apps/web): React/Vite dashboard served by a Caddy wrapper (static hosting plus `/api` reverse proxy).
 - [Backend API](../apps/backend/src): controllers and services for endpoints and business logic.
 - [Deal add-ons](../apps/backend/src/deal-addons) and [Retrieval add-ons](../apps/backend/src/retrieval-addons): deal/retrieval check integrations.
 - [Job execution](../apps/backend/src/jobs): pg-boss scheduler + workers for deal/retrieval jobs.
 - [Wallet + chain integration](../apps/backend/src/wallet-sdk): provider discovery and on-chain operations.
 - [Persistence](../apps/backend/src/database): deal/retrieval state plus pg-boss queue/schedule state in Postgres.
-- [Metrics](../apps/backend/src/metrics-prometheus): Prometheus instrumentation and `/metrics` exposure.
-- Metrics retention/alerting lives in external monitoring (Prometheus/Grafana/BetterStack); those systems are observability surfaces, not Dealbot source-of-truth state.
+- [Metrics](../apps/backend/src/metrics-prometheus): Prometheus instrumentation. Scrape surface and observability expectations live in [infra.md](infra.md).
 
 ## Data Stores and Ownership
 
@@ -37,13 +34,6 @@ Postgres is the system-of-record for Dealbot state:
 - Retrieval lifecycle records in `retrievals`.
 - Scheduler state in `job_schedule_state` and queue execution state in `pgboss.job`.
 
-ClickHouse is for long-term check result storage and analysis, it's optional:
+ClickHouse is an optional sink for long-term check result analysis. Each completed check writes one row to `data_storage_checks`, `retrieval_checks`, or `data_retention_challenges`. Rows are buffered and flushed in batches; failed flushes are logged and dropped. The service starts and runs without ClickHouse. Operator wiring is described in [infra.md](infra.md).
 
-- Each completed check writes one row to the relevant table: `data_storage_checks`, `retrieval_checks`, or `data_retention_challenges`.
-- Rows are buffered in memory and flushed in batches; failed flushes are logged and the batch is dropped (ClickHouse is a metrics sink, not a source of truth).
-- ClickHouse is not a dependency for normal operation. The service starts and runs without it.
-
-Prometheus is for runtime observability, not durable state:
-
-- Job health/performance metrics (for example `jobs_started_total`, `jobs_completed_total`, `jobs_queued`) are emitted at runtime on `/metrics`.
-- Grafana/BetterStack visualize scraped metrics and logs; these are monitoring surfaces and not canonical Dealbot state.
+Prometheus metrics are runtime observability, not durable state. Job health and per-check timing metrics are emitted at runtime; metric semantics live in [docs/checks/events-and-metrics.md](checks/events-and-metrics.md). External monitoring (Grafana, BetterStack, or other) is an observability surface, not canonical state.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,6 @@ Postgres is the system-of-record for Dealbot state:
 - Retrieval lifecycle records in `retrievals`.
 - Scheduler state in `job_schedule_state` and queue execution state in `pgboss.job`.
 
-ClickHouse is an optional append-only sink for long-term check result analysis. Rows are buffered and flushed in batches; failed flushes are logged and dropped. The service starts and runs without ClickHouse. Table layout and write cadence are documented in [docs/checks/events-and-metrics.md](checks/events-and-metrics.md); operator wiring is described in [infra.md](infra.md).
+ClickHouse is an optional append-only sink for long-term check result analysis. Rows are buffered and flushed in batches; failed flushes are logged and retried on the next flush, with the oldest rows dropped only if the buffer reaches `CLICKHOUSE_MAX_BUFFER_SIZE`. The service starts and runs without ClickHouse. Table layout is documented in [docs/checks/events-and-metrics.md](checks/events-and-metrics.md); operator wiring is described in [infra.md](infra.md).
 
 Prometheus metrics are runtime observability, not durable state. Job health and per-check timing metrics are emitted at runtime; metric semantics live in [docs/checks/events-and-metrics.md](checks/events-and-metrics.md). External monitoring (Grafana, BetterStack, or other) is an observability surface, not canonical state.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,7 @@ graph TD
 - [Job execution](../apps/backend/src/jobs): pg-boss scheduler + workers for deal/retrieval jobs.
 - [Wallet + chain integration](../apps/backend/src/wallet-sdk): provider discovery and on-chain operations.
 - [Persistence](../apps/backend/src/database): deal/retrieval state plus pg-boss queue/schedule state in Postgres.
-- [Metrics](../apps/backend/src/metrics-prometheus): Prometheus instrumentation. Scrape surface and observability expectations live in [infra.md](infra.md).
+- [Metrics](../apps/backend/src/metrics-prometheus): Prometheus instrumentation. Metric semantics live in [docs/checks/events-and-metrics.md](checks/events-and-metrics.md); observability wiring lives in [infra.md](infra.md).
 
 ## Data Stores and Ownership
 
@@ -34,6 +34,6 @@ Postgres is the system-of-record for Dealbot state:
 - Retrieval lifecycle records in `retrievals`.
 - Scheduler state in `job_schedule_state` and queue execution state in `pgboss.job`.
 
-ClickHouse is an optional sink for long-term check result analysis. Each completed check writes one row to `data_storage_checks`, `retrieval_checks`, or `data_retention_challenges`. Rows are buffered and flushed in batches; failed flushes are logged and dropped. The service starts and runs without ClickHouse. Operator wiring is described in [infra.md](infra.md).
+ClickHouse is an optional append-only sink for long-term check result analysis. Rows are buffered and flushed in batches; failed flushes are logged and dropped. The service starts and runs without ClickHouse. Table layout and write cadence are documented in [docs/checks/events-and-metrics.md](checks/events-and-metrics.md); operator wiring is described in [infra.md](infra.md).
 
 Prometheus metrics are runtime observability, not durable state. Job health and per-check timing metrics are emitted at runtime; metric semantics live in [docs/checks/events-and-metrics.md](checks/events-and-metrics.md). External monitoring (Grafana, BetterStack, or other) is an observability surface, not canonical state.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,7 +17,7 @@ The base manifests are intentionally minimal. Anything environment-specific (ing
 Backend pods select a role via `DEALBOT_RUN_MODE`:
 
 - `api`: serves HTTP. Does not consume pg-boss jobs.
-- `worker`: consumes pg-boss jobs. Job set: deal checks, retrieval checks, pull checks, dataset creation, piece cleanup (per provider), pull piece cleanup (global), provider refresh, data retention.
+- `worker`: consumes pg-boss jobs.
 - `both` (default): API listener and worker loop in one pod. Used by the base manifests when `DEALBOT_RUN_MODE` is unset. The local overlay overrides backend to `api` and adds a dedicated worker Deployment.
 
 The pg-boss scheduler that enqueues recurring jobs is gated independently by `DEALBOT_PGBOSS_SCHEDULER_ENABLED` (default `true`). Exactly one pod across the deployment should run the scheduler; on pods that should not, set the flag to `false` explicitly. The local overlay leaves it `true` on the `api` pod and sets `false` on workers.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,44 @@
+# Deployment Surface
+
+Dealbot drives automated storage and retrieval traffic against Filecoin storage providers (SPs): it submits deals, runs retrieval probes, and records the outcomes. It ships as two container images (`dealbot-backend`, `dealbot-web`) plus a set of Kustomize manifests that any Kubernetes environment can consume.
+
+For ingress, egress, persistence, secrets, and observability expectations around the application, see [infra.md](infra.md). For release and image promotion, see [release-process.md](release-process.md).
+
+## What this repo provides
+
+- Base manifests: `kustomize/base/backend/`, `kustomize/base/web/`
+- Local overlay: `kustomize/overlays/local/` (NodePort services, bundled Postgres, split API/worker pods; suitable for `kind`/`minikube`)
+- Container images at `ghcr.io/filozone/dealbot-backend` and `ghcr.io/filozone/dealbot-web` with SHA and semver tags ([release-process.md](release-process.md))
+
+The base manifests are intentionally minimal. Anything environment-specific (ingress, TLS, secret backend, replica counts, resource limits, image tags, split-pod topology) is supplied by an overlay.
+
+## Runtime topology
+
+Backend pods select a role via `DEALBOT_RUN_MODE`:
+
+- `api`: serves HTTP. Does not consume pg-boss jobs.
+- `worker`: consumes pg-boss jobs. Job set: deal checks, retrieval checks, pull checks, dataset creation, piece cleanup (per provider), pull piece cleanup (global), provider refresh, data retention.
+- `both` (default): API listener and worker loop in one pod. Used by the base manifests when `DEALBOT_RUN_MODE` is unset. The local overlay overrides backend to `api` and adds a dedicated worker Deployment.
+
+The pg-boss scheduler that enqueues recurring jobs is gated independently by `DEALBOT_PGBOSS_SCHEDULER_ENABLED` (default `true`). Exactly one pod across the deployment should run the scheduler; on pods that should not, set the flag to `false` explicitly. The local overlay leaves it `true` on the `api` pod and sets `false` on workers.
+
+Per-storage-provider exclusion is enforced inside pg-boss via a singleton queue keyed on SP address, so multiple worker replicas are safe. Job rates are configured via env:
+
+- `DEALS_PER_SP_PER_HOUR`
+- `DATASET_CREATIONS_PER_SP_PER_HOUR`
+- `RETRIEVALS_PER_SP_PER_HOUR`
+
+Full env contract: [apps/backend/README.md](../apps/backend/README.md#scheduling-configuration-pg-boss) and [docs/environment-variables.md](environment-variables.md). Secret keys (chain endpoints, wallet, database credentials) are listed in [apps/backend/.env.example](../apps/backend/.env.example).
+
+## Operating requirements
+
+- Postgres reachable from the cluster, with the `pgcrypto` extension enabled (pg-boss dependency). The local overlay bundles a Postgres pod; other environments bring their own.
+- A Secret named `dealbot-secrets` populated with the keys from `.env.example`. Any mechanism that materializes a Kubernetes Secret with those keys works.
+
+## Image tags
+
+- `sha-<git-sha>` and `sha-<run>-<sha>`: produced for backend or web when a merge to `main` matches the [docker-build](../.github/workflows/docker-build.yml) path filters (the app's directory, or shared workspace files like `pnpm-lock.yaml` / `pnpm-workspace.yaml`). Suitable for staging or preview environments.
+- `pre-release-<git-sha>`: produced for merges to the `pre-release` branch. Suitable for opt-in canary environments.
+- `vX.Y.Z`: produced by the release workflow when a Release PR merges. Suitable for production.
+
+Overlays can pin a specific tag, track SHA tags via ArgoCD Image Updater, or follow semver. See [release-process.md](release-process.md) for the promotion flow.

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -1,78 +1,83 @@
 # Infra Integration
 
-What an operator wiring dealbot into their own cluster needs from the surrounding infrastructure. For the application images and Kubernetes manifests dealbot ships, see [deployment.md](deployment.md).
+What an operator wiring dealbot into their own cluster needs from the surrounding infrastructure. For the application images and Kubernetes manifests dealbot ships, see [deployment.md](deployment.md). For the authoritative env variable reference, see [environment-variables.md](environment-variables.md).
 
 ## System boundary
 
 A running dealbot needs:
 
-- Backend pods (API and worker, see [deployment.md](deployment.md))
+- Backend pods (API and worker; see [deployment.md](deployment.md))
 - Web pod
 - Postgres (required)
-- ClickHouse (optional, append-only long-term store)
-- A Prometheus scrape path or equivalent for observability
+- ClickHouse (optional, append-only sink)
+- A way to scrape or ship the metrics dealbot emits (see [Observability](#observability))
 
 Everything else (ingress controller, secret manager, TLS automation, log shipper, alerting backend, backup tooling) is the operator's choice and is intentionally not prescribed here.
 
-## Ingress
+## Network
 
-Two public surfaces:
+### Ingress
 
-- **Backend API**: HTTP. Used by the web UI and by any external automation. Set `DEALBOT_API_PUBLIC_URL` to the URL the API is reachable at; the web UI reads this to call back. CORS allow-list is driven by `ALLOWED_ORIGINS` (empty disables CORS).
-- **Web UI**: static assets served behind a reverse proxy.
+Two public surfaces dealbot itself listens on:
+
+- **Backend API** (`apps/backend`): served on `DEALBOT_PORT`. Used by the web UI and any external automation. CORS allow-list is `DEALBOT_ALLOWED_ORIGINS` (comma-separated; empty disables CORS entirely).
+- **Web UI** (`apps/web`): static assets served behind a reverse proxy. The web UI reaches the backend at the URL baked in via `VITE_API_BASE_URL` (build-time) or supplied at runtime.
+
+Pull checks require **inbound reachability from storage providers**: during a pull check dealbot hands the SP a source URL of the form `<DEALBOT_API_PUBLIC_URL>/api/piece/<pieceCid>` and the SP fetches that endpoint. `DEALBOT_API_PUBLIC_URL` must therefore be a URL routable from SP networks, not just from inside the cluster.
 
 TLS termination, ingress controller choice, hostname assignment, and rate limiting are the operator's responsibility.
 
-## Egress
+### Egress
 
-Dealbot dials out; nothing dials into dealbot from SP infrastructure. Egress targets:
+Dealbot opens outbound connections to:
 
-- **Chain RPC** (`RPC_URL`): Filecoin EVM RPC. Read and write.
-- **PDP Verifier contract** and **FWSS** (on-chain): reached via `RPC_URL`.
+- **Chain RPC** (`RPC_URL`): Filecoin EVM RPC for reads and writes.
+- **PDP Verifier contract** and **FWSS**: reached via `RPC_URL`.
 - **PDP subgraph** (`PDP_SUBGRAPH_ENDPOINT`): GraphQL.
-- **SP HTTP endpoints**: per provider, discovered from chain state. Used for deal creation, retrieval probes, pull checks, piece status.
-- **IPNI indexer** (`filecoinpin` / IPNI lookup): used during deal verification and retrieval.
+- **Storage provider HTTP endpoints**: per-provider URLs discovered from chain state. Used for deal creation, retrieval probes, pull-check kickoff, and piece status. Hostnames are not known in advance.
+- **IPNI / filecoinpin lookup**: used during deal verification and retrieval.
+- **ClickHouse** (optional, `CLICKHOUSE_URL`).
 
-Firewall and proxy rules need to allow outbound HTTPS to arbitrary SP hostnames discovered at runtime.
+Firewall and proxy rules need to allow outbound network access to arbitrary SP hostnames discovered at runtime.
 
 ## Persistence
 
 Postgres is required.
 
-- Enable the `pgcrypto` extension (pg-boss dependency).
-- Migrations run on backend startup; the schema is owned by the configured `DATABASE_USER`.
-- pg-boss creates its own `pgboss` schema for queue state. Expect steady write churn proportional to job rates.
-- Backup posture, HA topology, and DR strategy are operator choice. Dealbot is the only writer in normal operation, so a standard logical backup is sufficient for restore.
+- Required extension: `pgcrypto`.
+- Schema migrations are run by the backend on startup in production from non-worker pods (`runMode != worker`). Worker pods assume migrations have already run and the `pgboss` schema exists.
+- pg-boss owns its own schema for queue state. Expect steady write churn proportional to job rates.
+- Backup, HA topology, and DR strategy are operator choice. Dealbot is the only writer in normal operation, so a standard logical backup is sufficient for restore.
 
 ClickHouse is optional and append-only. If `CLICKHOUSE_URL` is unset, ClickHouse writes are disabled and nothing else changes.
 
 ## Secrets
 
-The backend Deployment expects a Kubernetes Secret named `dealbot-secrets` populated with the keys in [`apps/backend/.env.example`](../apps/backend/.env.example). Categories:
+[environment-variables.md](environment-variables.md) is the authoritative env contract; [apps/backend/.env.example](../apps/backend/.env.example) is a starting set.
 
-- **Chain access**: `RPC_URL`, optional API token.
-- **Wallet**: `WALLET_PRIVATE_KEY` and/or `SESSION_KEY_PRIVATE_KEY`. See [runbooks/wallet-and-session-keys.md](runbooks/wallet-and-session-keys.md) for lifecycle and rotation.
-- **Database**: `DATABASE_HOST`, `DATABASE_USER`, `DATABASE_PASSWORD`, `DATABASE_NAME`.
-- **Optional sinks**: `CLICKHOUSE_URL`.
+The backend Deployment expects a Kubernetes Secret named `dealbot-secrets`. Populate it with the sensitive values: `DATABASE_PASSWORD`, one of `WALLET_PRIVATE_KEY` or `SESSION_KEY_PRIVATE_KEY`, and any credentials embedded in `RPC_URL` or `CLICKHOUSE_URL`. Non-sensitive config (`DATABASE_HOST`, `NETWORK`, etc.) can live in a ConfigMap or plain env.
 
-Rotation cadence, encryption-at-rest mechanism (SOPS, External Secrets, sealed-secrets, manual), and audit trail are operator choice.
+Rotation cadence, encryption-at-rest mechanism (SOPS, External Secrets, sealed-secrets, manual), and audit trail are operator choice. Wallet and session-key lifecycle is in [runbooks/wallet-and-session-keys.md](runbooks/wallet-and-session-keys.md).
 
 ## Observability
 
-Dealbot emits structured logs to stdout (JSON, NestJS Logger format) and Prometheus-style metrics. Metric semantics, label conventions, and per-check timing markers are documented in [docs/checks/events-and-metrics.md](checks/events-and-metrics.md).
+Dealbot emits:
 
-Set `DEALBOT_PROBE_LOCATION` to a stable string identifying the cluster or region; it is attached to outbound check metrics and helps correlate SP-side reports.
+- Structured logs to stdout (JSON, NestJS Logger format).
+- Prometheus-style metrics. Names, labels, and per-check timing markers are documented in [docs/checks/events-and-metrics.md](checks/events-and-metrics.md).
 
-The Prometheus scrape endpoint shape and stability are in flux. For the current scrape target and any temporary deprecation, check this file's revision history and the worker Deployment manifest in the operating environment.
+Set `DEALBOT_PROBE_LOCATION` to a stable string identifying the cluster or region; it is attached to outbound check metrics so SP-side reports can be correlated.
+
+The metrics surface is under active rework. For a current example of how the local stack scrapes and visualizes metrics, see [local-monitoring.md](local-monitoring.md). Operators should expect the production wiring to follow the same shape but should not assume a specific endpoint path or port.
 
 ## Monitoring expectations
 
 At minimum, alert on:
 
-- Job backlog growth in pg-boss (queue depth, oldest queued age)
+- pg-boss backlog growth (queue depth, oldest queued age)
 - Sustained failure rate per check type
 - Wallet or session-key readiness (insufficient balance, missing FWSS operator approval)
-- Postgres connection or replication lag
+- Postgres connection or replication health
 
 Thresholds and alert routing are operator choice.
 
@@ -85,13 +90,15 @@ To restore service after total cluster loss:
 3. Re-populate `dealbot-secrets`.
 4. Workers resume consuming pg-boss queues from restored state.
 
-ClickHouse and any external log/metric sinks are downstream observers, not sources of truth.
+ClickHouse and any external log or metric sinks are downstream observers, not sources of truth.
 
 ## See also
+
+For related context:
 
 - [deployment.md](deployment.md): container images, Kustomize manifests, run-mode topology, image tag shapes.
 - [docs/jobs.md](jobs.md): pg-boss job set and scheduling behavior.
 - [docs/environment-variables.md](environment-variables.md): authoritative env variable reference.
-- [docs/architecture.md](architecture.md): component graph.
+- [docs/architecture.md](architecture.md): component graph and data-store ownership.
 - [docs/checks/](checks/): per-check semantics and metric definitions.
-- [docs/local-monitoring.md](local-monitoring.md): local observability testing.
+- [docs/local-monitoring.md](local-monitoring.md): example metrics scrape and dashboards for the local overlay.

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -66,7 +66,7 @@ Dealbot emits:
 - Structured logs to stdout (JSON, NestJS Logger format).
 - Prometheus-style metrics. Names, labels, and per-check timing markers are documented in [docs/checks/events-and-metrics.md](checks/events-and-metrics.md).
 
-Set `DEALBOT_PROBE_LOCATION` to a stable string identifying the cluster or region; it is attached to outbound check metrics so SP-side reports can be correlated.
+Set `DEALBOT_PROBE_LOCATION` to a stable string identifying the cluster or region. When `CLICKHOUSE_URL` is configured, it is written as the `probe_location` column on every check row, which lets multi-region deployments be partitioned and compared.
 
 The metrics surface is under active rework. For a current example of how the local stack scrapes and visualizes metrics, see [local-monitoring.md](local-monitoring.md). Operators should expect the production wiring to follow the same shape but should not assume a specific endpoint path or port.
 

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -21,7 +21,7 @@ Everything else (ingress controller, secret manager, TLS automation, log shipper
 Two public surfaces dealbot itself listens on:
 
 - **Backend API** (`apps/backend`): served on `DEALBOT_PORT`. Used by the web UI and any external automation. CORS allow-list is `DEALBOT_ALLOWED_ORIGINS` (comma-separated; empty disables CORS entirely).
-- **Web UI** (`apps/web`): static assets served behind a reverse proxy. The web UI reaches the backend at the URL baked in via `VITE_API_BASE_URL` (build-time) or supplied at runtime.
+- **Web UI** (`apps/web`): static assets served behind a reverse proxy. The web UI reaches the "backend API" above at the URL baked in via `VITE_API_BASE_URL` (build-time) or supplied at runtime.
 
 Pull checks require **inbound reachability from storage providers**: during a pull check dealbot hands the SP a source URL of the form `<DEALBOT_API_PUBLIC_URL>/api/piece/<pieceCid>` and the SP fetches that endpoint. `DEALBOT_API_PUBLIC_URL` must therefore be a URL routable from SP networks, not just from inside the cluster.
 

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -35,7 +35,7 @@ Dealbot opens outbound connections to:
 - **PDP Verifier contract** and **FWSS**: reached via `RPC_URL`.
 - **PDP subgraph** (`PDP_SUBGRAPH_ENDPOINT`): GraphQL.
 - **Storage provider HTTP endpoints**: per-provider URLs discovered from chain state. Used for deal creation, retrieval probes, pull-check kickoff, and piece status. Hostnames are not known in advance.
-- **IPNI / filecoinpin lookup**: used during deal verification and retrieval.
+- **IPNI indexer (`filecoinpin.contact`)**: looked up during deal verification and retrieval to confirm SPs are advertising the content.
 - **ClickHouse** (optional, `CLICKHOUSE_URL`).
 
 Firewall and proxy rules need to allow outbound network access to arbitrary SP hostnames discovered at runtime.

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -1,91 +1,42 @@
-# Integration with FilOzone/infra
+# Deployment Surface
 
-This repo uses Kustomize for local and production deployments. The base manifests in `kustomize/base/` are intended to be reusable by FilOzone/infra, with overlays providing environment-specific changes.
+Dealbot drives automated storage and retrieval traffic against Filecoin storage providers (SPs): it submits deals, runs retrieval probes, and records the outcomes. It ships as two container images (`dealbot-backend`, `dealbot-web`) plus a set of Kustomize manifests that any Kubernetes environment can consume.
 
-## Where things live in this repo
+## What this repo provides
 
 - Base manifests: `kustomize/base/backend/`, `kustomize/base/web/`
-- Local overlay: `kustomize/overlays/local/`
+- Local overlay: `kustomize/overlays/local/` (NodePort services, bundled Postgres, split API/worker pods; suitable for `kind`/`minikube`)
+- Container images at `ghcr.io/filozone/dealbot-backend` and `ghcr.io/filozone/dealbot-web` with SHA and semver tags ([release-process.md](release-process.md))
 
-## What infra can customize
+The base manifests are intentionally minimal. Anything environment-specific (ingress, TLS, secret backend, replica counts, resource limits, image tags, split-pod topology) is supplied by an overlay.
 
-FilOzone/infra can override base manifests via overlays and patches. Common changes include:
+## Runtime topology
 
-- Namespace and naming conventions
-- Image registry/repository and tags
-- Service types, ports, and ingress configuration
-- Environment variables and config maps
-- Secrets management (SOPS/External Secrets)
-- Resource requests/limits and replica counts
-- Removing or replacing base resources (for example, replacing ingress)
+Backend pods select a role via `DEALBOT_RUN_MODE`:
 
-## Ingress boundaries
+- `api`: serves HTTP. Does not consume pg-boss jobs.
+- `worker`: consumes pg-boss jobs. Job set: deal checks, retrieval checks, pull checks, dataset creation, piece cleanup (per provider), pull piece cleanup (global), provider refresh, data retention.
+- `both` (default): API listener and worker loop in one pod. Used by the base manifests when `DEALBOT_RUN_MODE` is unset. The local overlay overrides backend to `api` and adds a dedicated worker Deployment.
 
-The base Ingress manifests are intentionally minimal and meant to be patched or replaced by infra based on the target environment.
+The pg-boss scheduler that enqueues recurring jobs is gated independently by `DEALBOT_PGBOSS_SCHEDULER_ENABLED` (default `true`). Exactly one pod across the deployment should run the scheduler; on pods that should not, set the flag to `false` explicitly. The local overlay leaves it `true` on the `api` pod and sets `false` on workers.
 
-- [kustomize/base/backend/ingress.yaml](../kustomize/base/backend/ingress.yaml)
-- [kustomize/base/web/ingress.yaml](../kustomize/base/web/ingress.yaml)
+Per-storage-provider exclusion is enforced inside pg-boss via a singleton queue keyed on SP address, so multiple worker replicas are safe. Job rates are configured via env:
 
-If the environment uses a different ingress controller or routing model, infra can patch or replace these resources.
+- `DEALS_PER_SP_PER_HOUR`
+- `DATASET_CREATIONS_PER_SP_PER_HOUR`
+- `RETRIEVALS_PER_SP_PER_HOUR`
 
-## Secrets expectations
+Full env contract: [apps/backend/README.md](../apps/backend/README.md#scheduling-configuration-pg-boss) and [docs/environment-variables.md](environment-variables.md). Secret keys (chain endpoints, wallet, database credentials) are listed in [apps/backend/.env.example](../apps/backend/.env.example).
 
-The backend deployment expects a Secret named `dealbot-secrets`. Infra can supply it via any secret management method (SOPS, External Secrets, or another controller).
+## Operating requirements
 
-For required keys and optional variables, see [apps/backend/.env.example](../apps/backend/.env.example).
+- Postgres reachable from the cluster, with the `pgcrypto` extension enabled (pg-boss dependency). The local overlay bundles a Postgres pod; other environments bring their own.
+- A Secret named `dealbot-secrets` populated with the keys from `.env.example`. Any mechanism that materializes a Kubernetes Secret with those keys works.
 
-## Image tags and promotion
+## Image tags
 
-- Main branch builds produce `sha-<sha>` and `sha-<run>-<sha>` tags for staging-style promotion.
-- Release builds produce semver tags (`vX.Y.Z`) for production promotion.
-- Infra can track SHA tags, semver tags, or pin a specific tag based on environment needs.
-- ArgoCD Image Updater is optional; its configuration lives in FilOzone/infra.
+- `sha-<git-sha>` and `sha-<run>-<sha>`: produced for backend or web when a merge to `main` matches the [docker-build](../.github/workflows/docker-build.yml) path filters (the app's directory, or shared workspace files like `pnpm-lock.yaml` / `pnpm-workspace.yaml`). Suitable for staging or preview environments.
+- `pre-release-<git-sha>`: produced for merges to the `pre-release` branch. Suitable for opt-in canary environments.
+- `vX.Y.Z`: produced by the release workflow when a Release PR merges. Suitable for production.
 
-## Local vs production notes
-
-- Local overlay uses NodePort services and bundled Postgres for fast iteration.
-- Bundled Postgres manifests live in `kustomize/overlays/local/postgres/`.
-- Infra typically switches services to ClusterIP, uses managed databases, and injects ingress/TLS settings.
-
-## Planned infra changes: pg-boss job runners
-
-Goal: replace in-process cron with pg-boss. Splitting workers into separate Deployments is a
-follow-on step; initial rollout keeps a single backend Deployment.
-
-### Application behavior
-
-- Dealbot uses pg-boss for all job scheduling with rate-based configuration:
-  - `DEALS_PER_SP_PER_HOUR`
-  - `DATASET_CREATIONS_PER_SP_PER_HOUR`
-  - `RETRIEVALS_PER_SP_PER_HOUR`
-- Deals and retrievals run per storage provider.
-- Scheduling is rate-based (per-hour), with catch-up after downtime.
-
-### Required infra changes in FilOzone/infra
-
-Phase 1 (pg-boss only, single Deployment):
-- No infra changes required beyond env vars and database extension enablement.
-- Keep the existing API deployment as the only backend pod.
- - Ensure `pgcrypto` extension is enabled in Postgres (pg-boss dependency).
-
-Phase 2 (optional, later): add worker Deployments (same backend image):
-  - `dealbot-deal-worker`
-  - `dealbot-retrieval-worker`
-- Keep existing API Deployment and disable job execution there.
-- Ensure worker pods do not match the API Service selector:
-  - keep API label as `app.kubernetes.io/name: dealbot`
-  - use a different label for workers (e.g., `dealbot-worker`)
-- Add env overrides per worker:
-  - API: `DEALBOT_RUN_MODE=api`, `DEALBOT_PGBOSS_SCHEDULER_ENABLED=true`
-  - Workers: `DEALBOT_RUN_MODE=worker`, `DEALBOT_PGBOSS_SCHEDULER_ENABLED=false`
-  - rate vars: `DEALS_PER_SP_PER_HOUR`, `DATASET_CREATIONS_PER_SP_PER_HOUR`, `RETRIEVALS_PER_SP_PER_HOUR`
-- Keep a single ConfigMap (`dealbot-env`) and override worker-specific env in patches.
-- Ensure `/datasets` volume mount remains on deal/retrieval workers.
-- Confirm ServiceMonitor continues to scrape only the API pods.
-
-### Notes / risks
-
-- Multiple replicas per worker type are allowed; per-SP exclusion is enforced by
-  the pg-boss `sp.work` singleton queue (`singletonKey=spAddress`), and per-job
-  concurrency limits must be set in the worker config.
-- Supabase is on Postgres 17 (per `select version()`); infra should align DB versions.
+Overlays can pin a specific tag, track SHA tags via ArgoCD Image Updater, or follow semver. See [release-process.md](release-process.md) for the promotion flow.

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -1,42 +1,97 @@
-# Deployment Surface
+# Infra Integration
 
-Dealbot drives automated storage and retrieval traffic against Filecoin storage providers (SPs): it submits deals, runs retrieval probes, and records the outcomes. It ships as two container images (`dealbot-backend`, `dealbot-web`) plus a set of Kustomize manifests that any Kubernetes environment can consume.
+What an operator wiring dealbot into their own cluster needs from the surrounding infrastructure. For the application images and Kubernetes manifests dealbot ships, see [deployment.md](deployment.md).
 
-## What this repo provides
+## System boundary
 
-- Base manifests: `kustomize/base/backend/`, `kustomize/base/web/`
-- Local overlay: `kustomize/overlays/local/` (NodePort services, bundled Postgres, split API/worker pods; suitable for `kind`/`minikube`)
-- Container images at `ghcr.io/filozone/dealbot-backend` and `ghcr.io/filozone/dealbot-web` with SHA and semver tags ([release-process.md](release-process.md))
+A running dealbot needs:
 
-The base manifests are intentionally minimal. Anything environment-specific (ingress, TLS, secret backend, replica counts, resource limits, image tags, split-pod topology) is supplied by an overlay.
+- Backend pods (API and worker, see [deployment.md](deployment.md))
+- Web pod
+- Postgres (required)
+- ClickHouse (optional, append-only long-term store)
+- A Prometheus scrape path or equivalent for observability
 
-## Runtime topology
+Everything else (ingress controller, secret manager, TLS automation, log shipper, alerting backend, backup tooling) is the operator's choice and is intentionally not prescribed here.
 
-Backend pods select a role via `DEALBOT_RUN_MODE`:
+## Ingress
 
-- `api`: serves HTTP. Does not consume pg-boss jobs.
-- `worker`: consumes pg-boss jobs. Job set: deal checks, retrieval checks, pull checks, dataset creation, piece cleanup (per provider), pull piece cleanup (global), provider refresh, data retention.
-- `both` (default): API listener and worker loop in one pod. Used by the base manifests when `DEALBOT_RUN_MODE` is unset. The local overlay overrides backend to `api` and adds a dedicated worker Deployment.
+Two public surfaces:
 
-The pg-boss scheduler that enqueues recurring jobs is gated independently by `DEALBOT_PGBOSS_SCHEDULER_ENABLED` (default `true`). Exactly one pod across the deployment should run the scheduler; on pods that should not, set the flag to `false` explicitly. The local overlay leaves it `true` on the `api` pod and sets `false` on workers.
+- **Backend API**: HTTP. Used by the web UI and by any external automation. Set `DEALBOT_API_PUBLIC_URL` to the URL the API is reachable at; the web UI reads this to call back. CORS allow-list is driven by `ALLOWED_ORIGINS` (empty disables CORS).
+- **Web UI**: static assets served behind a reverse proxy.
 
-Per-storage-provider exclusion is enforced inside pg-boss via a singleton queue keyed on SP address, so multiple worker replicas are safe. Job rates are configured via env:
+TLS termination, ingress controller choice, hostname assignment, and rate limiting are the operator's responsibility.
 
-- `DEALS_PER_SP_PER_HOUR`
-- `DATASET_CREATIONS_PER_SP_PER_HOUR`
-- `RETRIEVALS_PER_SP_PER_HOUR`
+## Egress
 
-Full env contract: [apps/backend/README.md](../apps/backend/README.md#scheduling-configuration-pg-boss) and [docs/environment-variables.md](environment-variables.md). Secret keys (chain endpoints, wallet, database credentials) are listed in [apps/backend/.env.example](../apps/backend/.env.example).
+Dealbot dials out; nothing dials into dealbot from SP infrastructure. Egress targets:
 
-## Operating requirements
+- **Chain RPC** (`RPC_URL`): Filecoin EVM RPC. Read and write.
+- **PDP Verifier contract** and **FWSS** (on-chain): reached via `RPC_URL`.
+- **PDP subgraph** (`PDP_SUBGRAPH_ENDPOINT`): GraphQL.
+- **SP HTTP endpoints**: per provider, discovered from chain state. Used for deal creation, retrieval probes, pull checks, piece status.
+- **IPNI indexer** (`filecoinpin` / IPNI lookup): used during deal verification and retrieval.
 
-- Postgres reachable from the cluster, with the `pgcrypto` extension enabled (pg-boss dependency). The local overlay bundles a Postgres pod; other environments bring their own.
-- A Secret named `dealbot-secrets` populated with the keys from `.env.example`. Any mechanism that materializes a Kubernetes Secret with those keys works.
+Firewall and proxy rules need to allow outbound HTTPS to arbitrary SP hostnames discovered at runtime.
 
-## Image tags
+## Persistence
 
-- `sha-<git-sha>` and `sha-<run>-<sha>`: produced for backend or web when a merge to `main` matches the [docker-build](../.github/workflows/docker-build.yml) path filters (the app's directory, or shared workspace files like `pnpm-lock.yaml` / `pnpm-workspace.yaml`). Suitable for staging or preview environments.
-- `pre-release-<git-sha>`: produced for merges to the `pre-release` branch. Suitable for opt-in canary environments.
-- `vX.Y.Z`: produced by the release workflow when a Release PR merges. Suitable for production.
+Postgres is required.
 
-Overlays can pin a specific tag, track SHA tags via ArgoCD Image Updater, or follow semver. See [release-process.md](release-process.md) for the promotion flow.
+- Enable the `pgcrypto` extension (pg-boss dependency).
+- Migrations run on backend startup; the schema is owned by the configured `DATABASE_USER`.
+- pg-boss creates its own `pgboss` schema for queue state. Expect steady write churn proportional to job rates.
+- Backup posture, HA topology, and DR strategy are operator choice. Dealbot is the only writer in normal operation, so a standard logical backup is sufficient for restore.
+
+ClickHouse is optional and append-only. If `CLICKHOUSE_URL` is unset, ClickHouse writes are disabled and nothing else changes.
+
+## Secrets
+
+The backend Deployment expects a Kubernetes Secret named `dealbot-secrets` populated with the keys in [`apps/backend/.env.example`](../apps/backend/.env.example). Categories:
+
+- **Chain access**: `RPC_URL`, optional API token.
+- **Wallet**: `WALLET_PRIVATE_KEY` and/or `SESSION_KEY_PRIVATE_KEY`. See [runbooks/wallet-and-session-keys.md](runbooks/wallet-and-session-keys.md) for lifecycle and rotation.
+- **Database**: `DATABASE_HOST`, `DATABASE_USER`, `DATABASE_PASSWORD`, `DATABASE_NAME`.
+- **Optional sinks**: `CLICKHOUSE_URL`.
+
+Rotation cadence, encryption-at-rest mechanism (SOPS, External Secrets, sealed-secrets, manual), and audit trail are operator choice.
+
+## Observability
+
+Dealbot emits structured logs to stdout (JSON, NestJS Logger format) and Prometheus-style metrics. Metric semantics, label conventions, and per-check timing markers are documented in [docs/checks/events-and-metrics.md](checks/events-and-metrics.md).
+
+Set `DEALBOT_PROBE_LOCATION` to a stable string identifying the cluster or region; it is attached to outbound check metrics and helps correlate SP-side reports.
+
+The Prometheus scrape endpoint shape and stability are in flux. For the current scrape target and any temporary deprecation, check this file's revision history and the worker Deployment manifest in the operating environment.
+
+## Monitoring expectations
+
+At minimum, alert on:
+
+- Job backlog growth in pg-boss (queue depth, oldest queued age)
+- Sustained failure rate per check type
+- Wallet or session-key readiness (insufficient balance, missing FWSS operator approval)
+- Postgres connection or replication lag
+
+Thresholds and alert routing are operator choice.
+
+## DR posture
+
+To restore service after total cluster loss:
+
+1. Restore Postgres from the most recent backup.
+2. Redeploy backend, worker, and web pods from pinned semver image tags ([release-process.md](release-process.md)).
+3. Re-populate `dealbot-secrets`.
+4. Workers resume consuming pg-boss queues from restored state.
+
+ClickHouse and any external log/metric sinks are downstream observers, not sources of truth.
+
+## See also
+
+- [deployment.md](deployment.md): container images, Kustomize manifests, run-mode topology, image tag shapes.
+- [docs/jobs.md](jobs.md): pg-boss job set and scheduling behavior.
+- [docs/environment-variables.md](environment-variables.md): authoritative env variable reference.
+- [docs/architecture.md](architecture.md): component graph.
+- [docs/checks/](checks/): per-check semantics and metric definitions.
+- [docs/local-monitoring.md](local-monitoring.md): local observability testing.

--- a/docs/infra.md
+++ b/docs/infra.md
@@ -23,7 +23,7 @@ Two public surfaces dealbot itself listens on:
 - **Backend API** (`apps/backend`): served on `DEALBOT_PORT`. Used by the web UI and any external automation. CORS allow-list is `DEALBOT_ALLOWED_ORIGINS` (comma-separated; empty disables CORS entirely).
 - **Web UI** (`apps/web`): static assets served behind a reverse proxy. The web UI reaches the "backend API" above at the URL baked in via `VITE_API_BASE_URL` (build-time) or supplied at runtime.
 
-Pull checks require **inbound reachability from storage providers**: during a pull check dealbot hands the SP a source URL of the form `<DEALBOT_API_PUBLIC_URL>/api/piece/<pieceCid>` and the SP fetches that endpoint. `DEALBOT_API_PUBLIC_URL` must therefore be a URL routable from SP networks, not just from inside the cluster.
+[Pull checks](checks/pull-check.md) require **inbound reachability from storage providers**: during a pull check dealbot hands the SP a source URL of the form `<DEALBOT_API_PUBLIC_URL>/api/piece/<pieceCid>` and the SP fetches that endpoint. `DEALBOT_API_PUBLIC_URL` must therefore be a URL routable from SP networks, not just from inside the cluster.
 
 TLS termination, ingress controller choice, hostname assignment, and rate limiting are the operator's responsibility.
 
@@ -31,14 +31,11 @@ TLS termination, ingress controller choice, hostname assignment, and rate limiti
 
 Dealbot opens outbound connections to:
 
-- **Chain RPC** (`RPC_URL`): Filecoin EVM RPC for reads and writes.
-- **PDP Verifier contract** and **FWSS**: reached via `RPC_URL`.
+- **Chain RPC** (`RPC_URL`): Filecoin EVM RPC for reads and writes. Reaches the **PDP Verifier contract** and **FWSS**.
 - **PDP subgraph** (`PDP_SUBGRAPH_ENDPOINT`): GraphQL.
-- **Storage provider HTTP endpoints**: per-provider URLs discovered from chain state. Used for deal creation, retrieval probes, pull-check kickoff, and piece status. Hostnames are not known in advance.
+- **Storage provider HTTP endpoints**: per-provider URLs discovered from chain state. Used for deal creation, retrieval probes, pull-check kickoff, and piece status. Hostnames are not known in advance, so firewall and proxy rules need to allow outbound network access to arbitrary SP hostnames discovered at runtime.
 - **IPNI indexer (`filecoinpin.contact`)**: looked up during deal verification and retrieval to confirm SPs are advertising the content.
 - **ClickHouse** (optional, `CLICKHOUSE_URL`).
-
-Firewall and proxy rules need to allow outbound network access to arbitrary SP hostnames discovered at runtime.
 
 ## Persistence
 
@@ -47,7 +44,7 @@ Postgres is required.
 - Required extension: `pgcrypto`.
 - Schema migrations are run by the backend on startup in production from non-worker pods (`runMode != worker`). Worker pods assume migrations have already run and the `pgboss` schema exists.
 - pg-boss owns its own schema for queue state. Expect steady write churn proportional to job rates.
-- Backup, HA topology, and DR strategy are operator choice. Dealbot is the only writer in normal operation, so a standard logical backup is sufficient for restore.
+- Backup, high-availability topology, and disaster-recovery strategy are operator choice. Dealbot is the only writer in normal operation, so a standard logical backup is sufficient for restore.
 
 ClickHouse is optional and append-only. If `CLICKHOUSE_URL` is unset, ClickHouse writes are disabled and nothing else changes.
 
@@ -81,7 +78,7 @@ At minimum, alert on:
 
 Thresholds and alert routing are operator choice.
 
-## DR posture
+## Disaster Recovery posture
 
 To restore service after total cluster loss:
 

--- a/docs/release-please-flow.md
+++ b/docs/release-please-flow.md
@@ -1,272 +1,58 @@
-# Release Flow with release-please
+# release-please Flow
 
-## Overview
+[release-please](https://github.com/googleapis/release-please) parses [Conventional Commits](https://www.conventionalcommits.org/) on `main` and maintains a single open Release PR per repository. For the end-to-end promotion flow (build, staging, retag, production), see [release-process.md](release-process.md).
 
-This repository uses **[release-please](https://github.com/googleapis/release-please)** by Google to automate versioning based on [Conventional Commits](https://www.conventionalcommits.org/).
+## How commits map to versions
 
-**Conventional Commits are essential for this flow.** release-please parses commits on `main` (subject, type, scope, breaking markers). Messages that are not valid Conventional Commits, or types that are not reflected in the changelog configuration, may be ignored—so **no release PR is created or updated** even though code merged.
+| Commit shape                                       | Default bump |
+|----------------------------------------------------|--------------|
+| `feat:`                                            | minor        |
+| `fix:` or any other configured `changelog-sections` type touching an app path | patch |
+| any type with `!` or a `BREAKING CHANGE:` footer   | major        |
 
-```
-Developer merges PR; mainline commit message is conventional and recognized
-  ↓
-release-please analyzes commits
-  ↓
-Creates/Updates "Release PR" with version bumps
-  ↓
-Developer merges Release PR
-  ↓
-Images retagged with semver
-  ↓
-ArgoCD Image Updater detects new version
-  ↓
-Manual sync required to deploy to production
-```
+A configured non-`feat`, non-breaking commit (e.g. `chore`, `docs`, `perf`, `refactor`, `build`, `ci`, `test`, `style`, `revert`) on an app path resolves to a patch when it triggers a release. For edge cases, defer to the [release-please versioning docs](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#versioning-strategies).
 
-**Note:** Production auto-sync is disabled initially for safety.
+Only commits touching files under an app's path affect that app's version. Backend and web are tagged independently as `backend-vX.Y.Z` and `web-vX.Y.Z`.
 
-## How we keep `main` commits compatible with release-please
+## Commit message contract
 
-These practices work together so merged commits stay parseable and release-please can stage production releases.
+release-please reads the **first line of the commit on `main`**. With the repository's default squash-merge subject, that first line is the PR title. Two safeguards keep that line parseable:
 
-1. **[PR Title workflow](../.github/workflows/pr-title.yml)** — On pull requests, [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request) validates the **PR title** against [Conventional Commits](https://www.conventionalcommits.org/). With no extra `types:` input, allowed types match [commitizen/conventional-commit-types](https://github.com/commitizen/conventional-commit-types) (e.g. `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`).
+1. [pr-title.yml](../.github/workflows/pr-title.yml) validates the PR title with [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request) against the action's default Conventional Commit types.
+2. [release-please-config.json](../release-please-config.json) lists the same types under `changelog-sections` with `hidden: false`, so those types appear in the changelog instead of being dropped.
 
-2. **Merge strategy** — Merge commits are **disabled** for pull requests. That steers merges toward **squash merge**, which—when the repository uses the default **“Use the PR title as the default squash merge commit subject”** (or equivalent)—makes the first line of the commit on `main` match the validated PR title. That line is what release-please sees for the merge.
+A type allowed by the PR title check but missing from `changelog-sections` will be ignored by release-please and produce no changelog entry.
 
-3. **[release-please-config.json](../release-please-config.json)** — Root [`changelog-sections`](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md) lists the same family of commit types with `"hidden": false`, so routine types (including `chore`, `ci`, `docs`, etc.) produce changelog content. Without that, release-please can treat those commits as “non user-facing,” skip opening or updating a release PR, and you would see **no staging release** despite merges.
-
-**Keep PR-title allowances and `changelog-sections` in sync:** Anything you add to allowed types in the PR title check should have a matching `changelog-sections` entry (same `type`, `hidden: false`) in [release-please-config.json](../release-please-config.json), or release-please may again skip releases for those commits.
-
-> **Squash message drift** — If someone **edits the squash merge message** so the first line is **not** valid Conventional Commits (wrong syntax, unknown type, typo in `feat`/`fix`/`chore`, etc.), or uses a type **not** listed in `changelog-sections`, release-please may **drop** that commit or produce **no** changelog entry. Then it may log something like “No user facing commits found … skipping” or “No commits for path … skipping,” and **a release PR will not be staged** for that change. Prefer leaving the default squash text (PR title) unchanged after it passed the PR title check.
-
-## Conventional Commits
-
-What lands on **`main`** (especially the **first line** of a squash merge) drives semver and the release PR. PR title validation does not re-check every intermediate commit on the branch—only the title at review time.
-
-### Commit types and version bumps
-
-Default release-please / Node versioning (unless you change [`versioning`](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#versioning-strategies) in config):
-
-| Commit prefix | Typical version bump | Example |
-|---------------|----------------------|---------|
-| `fix:`, `perf:`, `revert:`, and other non-`feat` types (e.g. `chore:`, `docs:`, `refactor:`, …) | **Patch** (0.1.0 → 0.1.1) | `fix: resolve payment bug` |
-| `feat:` | **Minor** (0.1.0 → 0.2.0) | `feat: add dark mode` |
-| `feat!:` or `BREAKING CHANGE:` in body/footer | **Major** (0.1.0 → 1.0.0) | `feat!: redesign API` |
-
-Dependency and housekeeping work (for example `chore(deps): …`) **does** count for staging a release, provided the message is conventional, the type is allowed on the PR, and the type appears in [release-please-config.json](../release-please-config.json) `changelog-sections`.
-
-Per-app paths (`apps/backend`, `apps/web`) still apply: only commits that touch files under a package’s path affect that component’s release.
-
-### Examples
-
-**Patch release (bug fix):**
-```bash
-git commit -m "fix: prevent duplicate transactions"
-# → Backend: 0.1.0 → 0.1.1 (when this commit touches apps/backend)
-```
-
-**Minor release (new feature):**
-```bash
-git commit -m "feat: add export to CSV functionality"
-# → Backend: 0.1.0 → 0.2.0 (when this commit touches apps/backend)
-```
-
-**Major release (breaking change):**
-```bash
-git commit -m "feat!: change API response format
-
-BREAKING CHANGE: Response structure changed from {data} to {result}"
-# → Backend: 0.1.0 → 1.0.0
-```
-
-**Patch / release staging (chore, CI, docs, etc.):**
-```bash
-git commit -m "chore(deps): bump library X"
-# → Patch bump and release PR update when apps/backend (or web) paths change,
-#    as long as the type is recognized and listed in changelog-sections.
-```
-
-## How It Works
-
-### 1. Merge Code with Conventional Commits
-
-```bash
-# Feature branch with conventional commits
-git checkout -b feat/user-export
-# ... make changes ...
-git commit -m "feat: add CSV export for users"
-git push
-
-# Create and merge PR (squash merge; keep default subject = PR title when prompted)
-```
-
-When merged to `main`:
-- SHA images built: `sha-abc123def456...` (full 40-char SHA)
-- Deployed to staging automatically
-
-### 2. release-please Creates/Updates Release PR
-
-**Automatically creates a PR titled like:**
-```
-chore: release to production (backend 0.2.0)
-```
-
-**The PR includes:**
-- ✅ Updated `apps/backend/package.json` version
-- ✅ Updated `apps/web/package.json` version (if changed)
-- ✅ Generated `CHANGELOG.md` entries
-- ✅ Grouped by app (backend/web)
-
-**Example PR:**
-```markdown
-## Backend 0.2.0
-
-### Features
-* add CSV export for users (abc123def456...)
-
-### Bug Fixes
-* prevent duplicate transactions (def456789abc...)
-
----
-
-## Web 0.1.1
-
-### Bug Fixes
-* fix button alignment on mobile (789abcdef012...)
-```
-
-### 3. Developer Reviews and Merges
-
-1. **Review the release PR**
-   - Check version bumps are correct
-   - Review changelog entries
-   - Verify images are in staging
-
-2. **Merge the PR**
-   - release-please creates git tags **only for apps with changes**:
-     - `backend-v0.2.0` (only if backend had changes)
-     - `web-v0.1.1` (only if web had changes)
-   - release-please creates GitHub Releases
-
-   > **Note:** Apps are released independently. If only web has changes, only `web-v*` is tagged and released. The [release workflow](../.github/workflows/release-please.yml) uses conditional checks ([backend](../.github/workflows/release-please.yml#L45) | [web](../.github/workflows/release-please.yml#L75)) to ensure images are only retagged when `*_release_created` is true for that component.
-
-3. **Workflow retags images** (conditionally, only for released components)
-   - `sha-abc123def456...` → `v0.2.0` (backend, if backend was released)
-   - `sha-def456789abc...` → `v0.1.1` (web, if web was released)
-
-4. **ArgoCD Image Updater detects new version**
-   - Image Updater watches for semver tags in GHCR
-   - Marks Application as OutOfSync
-
-5. **Manual deployment to production**
-   - Review changes in ArgoCD UI
-   - Sync manually via UI or CLI: `argocd app sync dealbot-backend-prod`
-   - Can enable auto-sync later once confidence is established
-
-## Per-App Versioning
-
-Each app has **independent versions** in `package.json`:
-
-```
-apps/backend/package.json: "version": "0.2.0"
-apps/web/package.json: "version": "0.1.1"
-```
-
-### Scenarios
-
-**Backend-only change:**
-```bash
-git commit -m "feat(backend): add new API endpoint"
-# → Backend: 0.1.0 → 0.2.0
-# → Web: 0.1.0 (no change)
-```
-
-**Web-only change:**
-```bash
-git commit -m "fix(web): button styling"
-# → Backend: 0.1.0 (no change)
-# → Web: 0.1.0 → 0.1.1
-```
-
-**Both change:**
-```bash
-git commit -m "feat: add user profiles
-- Add profile API endpoint (backend)
-- Add profile UI page (web)"
-# → Backend: 0.1.0 → 0.2.0
-# → Web: 0.1.0 → 0.2.0
-```
-
-## Benefits
-
-✅ **No manual version management** - Determined by commits
-✅ **Automatic CHANGELOGs** - Generated from commit messages
-✅ **Semantic versioning** - Industry standard
-✅ **Independent app versions** - Backend and web versioned separately
-✅ **Type-safe** - Uses existing `package.json` versions
-✅ **Conventional commits** - Align PR titles and mainline squash subjects with release automation
+Changing the squash subject before merge can prevent release-please from seeing the commit at all (see [Troubleshooting](#troubleshooting)).
 
 ## Configuration
 
-### release-please-config.json
-
-See [release-please-config.json](../release-please-config.json) for the complete configuration.
-
-Key settings:
-- `changelog-sections` → Maps conventional **types** to changelog sections with `hidden: false` so merges using those types still open/update release PRs (aligned with [pr-title.yml](../.github/workflows/pr-title.yml) / commitizen defaults)
-- `separate-pull-requests: false` → Single PR for all apps
-- `release-type: node` → Uses package.json for versioning
-- Configures independent versioning for backend and web apps
-
-### .release-please-manifest.json
-
-See [.release-please-manifest.json](../.release-please-manifest.json) for current versions.
-
-Tracks last released versions. Updated automatically by release-please.
+- [release-please-config.json](../release-please-config.json): `changelog-sections`, package paths under `packages`, `release-type: node` set per package, `separate-pull-requests: false`.
+- [.release-please-manifest.json](../.release-please-manifest.json): last released versions, updated by release-please.
 
 ## Hotfixes
 
-For urgent fixes, still use conventional commits:
+Use `fix:` for a patch bump. Use `fix!:` with a `BREAKING CHANGE:` footer only when the fix is genuinely incompatible (this bumps major).
 
-```bash
-git commit -m "fix!: critical security patch
-
-BREAKING CHANGE: describe the incompatible change
-
-SECURITY: Fixes CVE-2024-xxxxx"
 ```
+fix!: invalidate old session tokens
 
-`fix!` / `BREAKING CHANGE` triggers a **major** bump with default versioning. For a **patch-only** hotfix, use `fix:` (no `!`) and no breaking footer. Label the PR for faster review as needed.
+BREAKING CHANGE: clients must re-authenticate after upgrade.
+```
 
 ## Troubleshooting
 
-### Release PR not created
+**No Release PR after merge.** Check in order:
 
-**Check:**
-- Does the commit on `main` use valid **Conventional Commits** on the **first line** (especially after squash merge)?
-- Did the squash subject drift from the PR title (manual edit, unknown type, or non-conventional text)?
-- Does the commit **type** appear in [release-please-config.json](../release-please-config.json) `changelog-sections` (and is it allowed by [pr-title.yml](../.github/workflows/pr-title.yml))?
-- Did you merge to `main`?
-- For the component you expect: did the merge touch files under `apps/backend` or `apps/web`?
+1. The merge commit's first line on `main` is valid Conventional Commits. A non-conventional or unknown-type subject can cause release-please to log `No user facing commits found … skipping`.
+2. Verify the commit type appears in [release-please-config.json](../release-please-config.json) `changelog-sections`. If the PR title check allowed a type that is not in the config, release-please drops it.
+3. The diff touched `apps/backend` or `apps/web`. Changes outside both paths do not produce a release.
+4. If everything above checks out, the commit may have landed in an existing open Release PR rather than opening a new one. Look for the open Release PR.
 
-**Fix:**
-- Prefer **squash merge** with the **default subject = PR title** so the validated title becomes the commit message release-please parses.
-- Align PR title types with `changelog-sections` when you add new allowed types.
-- If needed, manually trigger (retries release/retagging): `gh workflow run release-please.yml` (use this only when images for the target commit already exist in GHCR)
+**Wrong version bump.** Close the Release PR, push a corrective commit, and let release-please reopen it.
 
-### Wrong version bump
+**Re-run the release workflow** (only when images for the target commit already exist in GHCR):
 
-**Fix:**
-- Close the release PR
-- Update commit messages if needed
-- Push new commit
-- release-please will update the PR
-
-### Need to skip a release
-
-Just don't merge the release PR. Commits will accumulate and be included in the next release.
-
-## References
-
-- [Conventional Commits](https://www.conventionalcommits.org/)
-- [release-please Documentation](https://github.com/googleapis/release-please)
-- [Semantic Versioning](https://semver.org/)
+```bash
+gh workflow run release-please.yml
+```

--- a/docs/release-please-flow.md
+++ b/docs/release-please-flow.md
@@ -6,9 +6,9 @@
 
 | Commit shape                                       | Default bump |
 |----------------------------------------------------|--------------|
+| any type with `!` or a `BREAKING CHANGE:` footer   | major        |
 | `feat:`                                            | minor        |
 | `fix:` or any other configured `changelog-sections` type touching an app path | patch |
-| any type with `!` or a `BREAKING CHANGE:` footer   | major        |
 
 A configured non-`feat`, non-breaking commit (e.g. `chore`, `docs`, `perf`, `refactor`, `build`, `ci`, `test`, `style`, `revert`) on an app path resolves to a patch when it triggers a release. For edge cases, defer to the [release-please versioning docs](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#versioning-strategies).
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,6 +1,6 @@
 # Release Process
 
-Dealbot uses [release-please](https://github.com/googleapis/release-please) to drive semver releases from [Conventional Commits](https://www.conventionalcommits.org/), and ArgoCD Image Updater to promote those releases into Kubernetes. For release-please mechanics (commit parsing, version bumps, troubleshooting) see [release-please-flow.md](release-please-flow.md); for deployment surface and overlay expectations see [infra.md](infra.md).
+Dealbot uses [release-please](https://github.com/googleapis/release-please) to drive semver releases from [Conventional Commits](https://www.conventionalcommits.org/), and ArgoCD Image Updater to promote those releases into Kubernetes. For release-please mechanics (commit parsing, version bumps, troubleshooting) see [release-please-flow.md](release-please-flow.md). For container images, manifests, and runtime topology see [deployment.md](deployment.md). For ingress, egress, persistence, secrets, and observability expectations see [infra.md](infra.md).
 
 ## Flow
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,128 +1,44 @@
-# Automated Release Process
+# Release Process
 
-This repository uses an automated GitOps release workflow to promote changes from staging to production.
+Dealbot uses [release-please](https://github.com/googleapis/release-please) to drive semver releases from [Conventional Commits](https://www.conventionalcommits.org/), and ArgoCD Image Updater to promote those releases into Kubernetes. For release-please mechanics (commit parsing, version bumps, troubleshooting) see [release-please-flow.md](release-please-flow.md); for deployment surface and overlay expectations see [infra.md](infra.md).
 
-Related docs:
-- [release-please-flow.md](release-please-flow.md) for release-please details and troubleshooting
-- [infra.md](infra.md) for ArgoCD/Kustomize integration in FilOzone/infra
-
-## Overview
+## Flow
 
 ```
-Code merged to main
-  ↓
-Build Docker images (e.g., sha-<sha> and sha-<run>-<sha>)
-  ↓
-ArgoCD auto-deploys to STAGING (watches ordered tags via Image Updater)
-  ↓
-release-please opens/updates Release PR (title includes component + version)
-  ↓
-Developer reviews and merges PR
-  ↓
-Retag same images with semver (e.g., v1.2.3)
-  ↓
-ArgoCD Image Updater detects new version in PRODUCTION
-  ↓
-Manual approval required to sync (initially)
+PR merged to main, matching docker-build path filters (apps/backend/**, apps/web/**, pnpm-lock.yaml, pnpm-workspace.yaml)
+  → Docker build tags image as sha-<sha> and sha-<run>-<sha>
+  → Image Updater promotes sha-<run>-<sha> to the staging environment
+  → release-please opens or updates a Release PR with bumped versions and changelogs
+  → Release PR merged                       (← human release gate)
+  → Release workflow retags sha-<sha> → vX.Y.Z
+  → Image Updater promotes vX.Y.Z to the production environment
 ```
 
-**Note:** Production auto-sync is disabled initially for safety. After confidence is established, it can be enabled.
+Both staging and production sync automatically. Image Updater writes the new tag back to the operating environment's manifests, and ArgoCD reconciles within a few minutes. Merging the Release PR is the release-cut gate for production semver images; retag and promotion run without further approval. An operator can still pause or sync manually per environment (see [Operating the release](#operating-the-release)).
 
-## How It Works
+Image-build scope and release scope differ. Changes under `apps/backend/**`, `apps/web/**`, `pnpm-lock.yaml`, or `pnpm-workspace.yaml` can build app images. Only commits that touch an app's path (`apps/backend` or `apps/web`) affect that app's release-please version.
 
-### 1. Merge to Main
+## Tags
 
-When you merge a PR to `main`, the release pipeline starts.
+Git tags and container tags use different shapes:
 
-### 2. Build Docker Images ([.github/workflows/docker-build.yml](../.github/workflows/docker-build.yml))
+| Tag                     | Producer                | Consumed by               |
+|-------------------------|-------------------------|---------------------------|
+| `backend-vX.Y.Z` / `web-vX.Y.Z` (git) | release-please | GitHub Releases, changelogs |
+| `sha-<sha>` (image)            | docker-build on `main`         | retag step                |
+| `sha-<run>-<sha>` (image)      | docker-build on `main`         | staging Image Updater     |
+| `pre-release-<sha>` (image)    | docker-build on `pre-release`  | opt-in canary environments |
+| `vX.Y.Z` (image)               | release-please workflow        | production Image Updater  |
 
-- Detects which apps changed (backend, web, or both)
-- Builds images only for changed apps
-- Tags:
-  - `sha-<git-sha>` (stable pointer used for promotion/retagging)
-  - `sha-<run-number>-<git-sha>` (monotonic tag used for staging)
-- Example: `ghcr.io/filozone/dealbot-backend:sha-1234-<sha>`
+Apps are versioned independently. A commit that touches only one app produces a Release PR entry, git tag, and retagged image for only that app.
 
-### 3. ArgoCD Deploys to Staging
+Workflows: [.github/workflows/docker-build.yml](../.github/workflows/docker-build.yml), [.github/workflows/release-please.yml](../.github/workflows/release-please.yml).
 
-- ArgoCD Image Updater watches ordered `sha-<run>-<sha>` tags in staging
-- Automatically deploys new images to staging
+## Operating the release
 
-### 4. release-please Opens/Updates the Release PR
+1. Merge feature PRs to `main` using a Conventional Commit title (validated by [pr-title.yml](../.github/workflows/pr-title.yml)).
+2. Staging picks up the new build automatically.
+3. When ready to ship, merge the open Release PR.
+4. Production picks up the new semver tag automatically.
 
-- release-please opens/updates a single PR titled like `chore: release to production (backend 0.2.0, web 0.5.0)`, listing all components that have changes
-- Includes per-app `package.json` version bumps and changelog entries
-- See [release-please-flow.md](release-please-flow.md) for versioning details
-
-### 5. Review and Merge the Release PR
-
-- Review the auto-created PR
-- If the bump looks wrong, update commits and let release-please refresh the PR
-- Merge the PR when ready to promote to production
-
-### 6. Retag Images with Semver
-
-- The release workflow retags the same `sha-<sha>` images as `vX.Y.Z`
-- Only apps with a release are retagged
-
-### 7. ArgoCD Detects New Version in Production
-
-- Image Updater sees the new semver tags and marks apps OutOfSync
-
-### 8. Manual Approval to Sync Production
-
-- Sync via ArgoCD UI or CLI (`argocd app sync dealbot-backend-prod`)
-
-## Examples
-
-### Example 1: Backend-only change
-
-```bash
-# Developer merges PR that changes backend code
-git merge feat/new-api-endpoint
-```
-
-**Result:**
-- ✅ Backend image built: `filoz-dealbot:sha-a1b2c3d`
-- ❌ Web image skipped (no changes)
-- 🚀 ArgoCD deploys backend to staging
-- 📝 Release PR updated: `chore: release to production`
-  - When the release PR is merged:
-     - Will only promote backend image
-     - Web stays at current version
-
-### Example 2: Dependency update
-
-```bash
-# Developer updates dependencies
-pnpm update
-git commit -am "chore: update dependencies"
-```
-
-**Result:**
-- ✅ Both images built (pnpm-lock.yaml changed)
-- 🚀 ArgoCD deploys both to staging
-- 📝 Release PR updated: `chore: release to production`
-  - Includes changes for both apps
-
-### Example 3: Hotfix (patch release)
-
-```bash
-# Developer merges a fix with a conventional commit (patch bump)
-git commit -m "fix: resolve critical issue"
-git push
-
-# release-please updates the Release PR with a patch bump
-# Developer merges the Release PR
-```
-
-**Result:**
-- 🏷️ Images retagged as `v0.2.1`
-- 🚀 Deployed to production as patch release
-
-## References
-
-- [release-please-flow.md](release-please-flow.md) - release-please behavior and troubleshooting
-- [infra.md](infra.md) - infra integration and where ArgoCD/Image Updater config lives
-- [.github/workflows/docker-build.yml](../.github/workflows/docker-build.yml)
-- [.github/workflows/release-please.yml](../.github/workflows/release-please.yml)
+If a release needs to be skipped, leave the Release PR open. Subsequent merges accumulate into it. To hold a release after the Release PR merges (e.g. a canary failed, on-call paged), pause auto-sync for that environment in ArgoCD. While paused, promote by syncing that environment manually via UI or CLI.


### PR DESCRIPTION
## What changed

Rewrote `docs/infra.md`, `docs/release-process.md`, and `docs/release-please-flow.md` so they describe the current operating state instead of the pre-GA roadmap. Fixes the two inaccuracies called out in #541 (shipped pg-boss worker split still labeled "planned"; false "manual approval to sync production" claim) and aligns the docs with a future-oriented voice for maintainers, drive-by contributors, and SP operators.

## How to verify

1. Read each file end-to-end as a new reader. Confirm no roadmap framing, no `/metrics` scrape mention, no private infra repo name.
2. Spot-check the technical claims against `apps/backend/src/config/app.config.ts`, `kustomize/overlays/local/dealbot-worker-deployment.yaml`, `.github/workflows/docker-build.yml`, `.github/workflows/release-please.yml`, and `release-please-config.json`.
3. Confirm the bump table in `release-please-flow.md` matches the [release-please default strategy](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#versioning-strategies).

## Notes

- Cross-reviewed by four independent agents (Cursor, Claude, Codex, Gemini); all four returned yes on accuracy and skill compliance after v5.
- The `/metrics` HTTP endpoint is being deprecated, so it was dropped from these docs. The worker liveness probe in the operating environment still hits `/metrics` and will need a follow-up before the endpoint is removed.

Closes #541.