### PR TITLE
fix(retrieval): filter random deal selection by wallet address

### DIFF
--- a/apps/backend/src/retrieval/retrieval.service.spec.ts
+++ b/apps/backend/src/retrieval/retrieval.service.spec.ts
@@ -574,7 +574,7 @@ describe("RetrievalService DB/provider drift", () => {
   const mockConfigService = {
     get: vi.fn((key: string) => {
       if (key === "jobs") return { mode: "cron" };
-      if (key === "blockchain") return { useOnlyApprovedProviders: false };
+      if (key === "blockchain") return { useOnlyApprovedProviders: false, walletAddress: "0x123" };
       if (key === "dataset") return { randomDatasetSizes: [10] };
       if (key === "timeouts") return { ipniVerificationTimeoutMs: 10_000, ipniVerificationPollingMs: 2_000 };
       return undefined;
@@ -628,6 +628,10 @@ describe("RetrievalService DB/provider drift", () => {
     const cleanedUpCall = calls.find((c) => c.clause.includes("cleaned_up"));
     expect(cleanedUpCall).toBeDefined();
     expect(cleanedUpCall?.params).toEqual({ cleanedUp: false });
+
+    const walletAddressCall = calls.find((c) => c.clause.includes("wallet_address"));
+    expect(walletAddressCall).toBeDefined();
+    expect(walletAddressCall?.params).toEqual({ walletAddress: "0x123" });
   });
 });
 

--- a/apps/backend/src/retrieval/retrieval.service.ts
+++ b/apps/backend/src/retrieval/retrieval.service.ts
@@ -446,11 +446,13 @@ export class RetrievalService {
    * Uses Postgres ORDER BY RANDOM() since Dealbot is Postgres-only.
    */
   private async selectRandomSuccessfulDealForProvider(spAddress: string): Promise<Deal | null> {
+    const walletAddress = this.configService.get("blockchain", { infer: true }).walletAddress;
     const randomDatasetSizes = this.getRandomDatasetSizes();
     const query = this.dealRepository
       .createQueryBuilder("deal")
       .innerJoin("deal.storageProvider", "sp", "sp.isActive = :isActive", { isActive: true })
       .where("deal.sp_address = :spAddress", { spAddress })
+      .andWhere("deal.wallet_address = :walletAddress", { walletAddress })
       .andWhere("deal.status IN (:...statuses)", {
         statuses: [DealStatus.DEAL_CREATED],
       })


### PR DESCRIPTION
https://filecoinproject.slack.com/archives/C07CGTXHHT4/p1779381027144089

This PR fixes the issue discussed in the above Slack thread.
```
Dealbot’s payer wallet was rotated on 2026-03-29 (calibration) and 2026-04-02 (mainnet). Deals created by the prior wallet were left in dealbot’s database without a cleaned_up marker, so the retrieval scheduler kept probing them. Most of those datasets had been terminated on chain after the rotation, and the SPs had correctly purged the pieces. Each probe returned 404 piece missing, dragging the displayed success rate down.
```

This change filters deals before retrieval scheduling to only consider deals associated with the currently active Dealbot wallet.