### PR TITLE
fix(deal): wire abort signal and graceful pg-boss drain

### DIFF
--- a/apps/backend/src/config/app.config.ts
+++ b/apps/backend/src/config/app.config.ts
@@ -96,7 +96,7 @@ export const configValidationSchema = Joi.object({
   // Seconds to hold the process alive after pg-boss drain completes, so Prometheus
   // captures at least one scrape of the terminal counter increments emitted during
   // shutdown. Default 35 covers the 30s ServiceMonitor interval plus a 5s buffer.
-  SHUTDOWN_FINAL_SCRAPE_DELAY_SECONDS: Joi.number().min(0).default(35),
+  SHUTDOWN_FINAL_SCRAPE_DELAY_SECONDS: Joi.number().min(0).max(300).default(35),
   IPFS_BLOCK_FETCH_CONCURRENCY: Joi.number().integer().min(1).max(32).default(6),
 
   // Pull Check

--- a/apps/backend/src/config/app.config.ts
+++ b/apps/backend/src/config/app.config.ts
@@ -93,6 +93,10 @@ export const configValidationSchema = Joi.object({
   DEAL_JOB_TIMEOUT_SECONDS: Joi.number().min(120).default(360), // 6 minutes max runtime for data storage jobs (TODO: reduce default to 3 minutes)
   RETRIEVAL_JOB_TIMEOUT_SECONDS: Joi.number().min(60).default(60), // 1 minute max runtime for retrieval jobs (TODO: reduce default to 30 seconds)
   DATA_SET_CREATION_JOB_TIMEOUT_SECONDS: Joi.number().min(60).default(300), // 5 minutes max runtime for dataset creation jobs
+  // Seconds to hold the process alive after pg-boss drain completes, so Prometheus
+  // captures at least one scrape of the terminal counter increments emitted during
+  // shutdown. Default 35 covers the 30s ServiceMonitor interval plus a 5s buffer.
+  SHUTDOWN_FINAL_SCRAPE_DELAY_SECONDS: Joi.number().min(0).default(35),
   IPFS_BLOCK_FETCH_CONCURRENCY: Joi.number().integer().min(1).max(32).default(6),
 
   // Pull Check
@@ -287,6 +291,11 @@ export interface IJobsConfig {
    */
   retrievalJobTimeoutSeconds: number;
   /**
+   * Seconds to hold the process alive after pg-boss drain finishes, so Prometheus
+   * scrapes the terminal counter increments emitted during shutdown.
+   */
+  shutdownFinalScrapeDelaySeconds: number;
+  /**
    * Target number of piece cleanup runs per storage provider per hour.
    *
    * Increasing this makes cleanup more aggressive at the cost of more SP API calls.
@@ -475,6 +484,7 @@ export function loadConfig(): IConfig {
       dealJobTimeoutSeconds: Number.parseInt(process.env.DEAL_JOB_TIMEOUT_SECONDS || "360", 10),
       retrievalJobTimeoutSeconds: Number.parseInt(process.env.RETRIEVAL_JOB_TIMEOUT_SECONDS || "60", 10),
       dataSetCreationJobTimeoutSeconds: Number.parseInt(process.env.DATA_SET_CREATION_JOB_TIMEOUT_SECONDS || "300", 10),
+      shutdownFinalScrapeDelaySeconds: Number.parseInt(process.env.SHUTDOWN_FINAL_SCRAPE_DELAY_SECONDS || "35", 10),
       pieceCleanupPerSpPerHour: Number.parseFloat(process.env.JOB_PIECE_CLEANUP_PER_SP_PER_HOUR || String(1 / 24)),
       maxPieceCleanupRuntimeSeconds: Number.parseInt(process.env.MAX_PIECE_CLEANUP_RUNTIME_SECONDS || "300", 10),
     },

--- a/apps/backend/src/deal/deal.service.ts
+++ b/apps/backend/src/deal/deal.service.ts
@@ -280,6 +280,7 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
     let retrievalStarted = false;
     let retrievalStatusEmitted = false;
     let preUploadTerminated = false;
+    let dataStorageStatusEmitted = false;
 
     let deal: Deal;
     if (existingDealId) {
@@ -378,150 +379,154 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
       deal.dataSetId = storage.dataSetId ?? null;
       deal.uploadStartTime = new Date();
 
-      const uploadResult = await executeUpload(synapse, uploadPayload.carData, uploadPayload.rootCid, {
-        logger: filecoinPinLogger,
-        contextId: providerAddress,
-        pieceMetadata: dealInput.synapseConfig.pieceMetadata,
-        contexts: [storage],
-        /**
-         * do not do IPNI validation here, we need to call /pdp/piece/<pieceCid>/status to get other metrics.
-         * See `onStored` handler in deal-addons/strategies/ipni.strategy.ts for implementation.
-         */
-        ipniValidation: { enabled: false },
-        // Must stay synchronous — Synapse SDK's safeInvoke discards the returned promise. See issue #446.
-        onProgress: (event) => {
-          this.logger.debug({
-            ...dealLogContext,
-            event: "upload_progress",
-            message: "Upload in progress",
-            filecoinPinEventType: event.type,
-          });
-          switch (event.type) {
-            case "stored": {
-              deal.uploadEndTime = new Date();
-              deal.status = DealStatus.UPLOADED;
-              deal.ingestLatencyMs = null;
-              deal.ingestThroughputBps = null;
+      const uploadResult = await awaitWithAbort(
+        executeUpload(synapse, uploadPayload.carData, uploadPayload.rootCid, {
+          logger: filecoinPinLogger,
+          contextId: providerAddress,
+          pieceMetadata: dealInput.synapseConfig.pieceMetadata,
+          contexts: [storage],
+          signal,
+          /**
+           * do not do IPNI validation here, we need to call /pdp/piece/<pieceCid>/status to get other metrics.
+           * See `onStored` handler in deal-addons/strategies/ipni.strategy.ts for implementation.
+           */
+          ipniValidation: { enabled: false },
+          // Must stay synchronous — Synapse SDK's safeInvoke discards the returned promise. See issue #446.
+          onProgress: (event) => {
+            this.logger.debug({
+              ...dealLogContext,
+              event: "upload_progress",
+              message: "Upload in progress",
+              filecoinPinEventType: event.type,
+            });
+            switch (event.type) {
+              case "stored": {
+                deal.uploadEndTime = new Date();
+                deal.status = DealStatus.UPLOADED;
+                deal.ingestLatencyMs = null;
+                deal.ingestThroughputBps = null;
 
-              const uploadStartTime = deal.uploadStartTime;
-              const uploadEndTime = deal.uploadEndTime;
-              if (uploadStartTime == null) {
-                this.logger.warn({
-                  ...dealLogContext,
-                  event: "ingest_metrics_skipped_missing_upload_start_time",
-                  message: "Skipping ingest metrics: uploadStartTime is missing",
-                  uploadEndTime,
-                });
-              } else {
-                const ingestLatencyMs = uploadEndTime.getTime() - uploadStartTime.getTime();
-                if (!Number.isFinite(ingestLatencyMs) || ingestLatencyMs <= 0) {
+                const uploadStartTime = deal.uploadStartTime;
+                const uploadEndTime = deal.uploadEndTime;
+                if (uploadStartTime == null) {
                   this.logger.warn({
                     ...dealLogContext,
-                    event: "ingest_metrics_skipped_invalid_latency",
-                    message: "Skipping ingest metrics: invalid ingest latency",
-                    uploadStartTime,
+                    event: "ingest_metrics_skipped_missing_upload_start_time",
+                    message: "Skipping ingest metrics: uploadStartTime is missing",
                     uploadEndTime,
-                    ingestLatencyMs,
                   });
                 } else {
-                  deal.ingestLatencyMs = ingestLatencyMs;
-                  this.dataStorageMetrics.observeIngestMs(providerLabels, ingestLatencyMs);
-
-                  const ingestSeconds = ingestLatencyMs / 1000;
-                  const ingestThroughputBps = Math.round(deal.fileSize / ingestSeconds);
-                  if (!Number.isFinite(ingestThroughputBps) || ingestThroughputBps <= 0) {
+                  const ingestLatencyMs = uploadEndTime.getTime() - uploadStartTime.getTime();
+                  if (!Number.isFinite(ingestLatencyMs) || ingestLatencyMs <= 0) {
                     this.logger.warn({
                       ...dealLogContext,
-                      event: "ingest_throughput_skipped_invalid_value",
-                      message: "Skipping ingest throughput metric: invalid throughput value",
+                      event: "ingest_metrics_skipped_invalid_latency",
+                      message: "Skipping ingest metrics: invalid ingest latency",
+                      uploadStartTime,
+                      uploadEndTime,
                       ingestLatencyMs,
-                      fileSize: deal.fileSize,
-                      ingestThroughputBps,
                     });
                   } else {
-                    deal.ingestThroughputBps = ingestThroughputBps;
-                    this.dataStorageMetrics.observeIngestThroughput(providerLabels, ingestThroughputBps);
+                    deal.ingestLatencyMs = ingestLatencyMs;
+                    this.dataStorageMetrics.observeIngestMs(providerLabels, ingestLatencyMs);
+
+                    const ingestSeconds = ingestLatencyMs / 1000;
+                    const ingestThroughputBps = Math.round(deal.fileSize / ingestSeconds);
+                    if (!Number.isFinite(ingestThroughputBps) || ingestThroughputBps <= 0) {
+                      this.logger.warn({
+                        ...dealLogContext,
+                        event: "ingest_throughput_skipped_invalid_value",
+                        message: "Skipping ingest throughput metric: invalid throughput value",
+                        ingestLatencyMs,
+                        fileSize: deal.fileSize,
+                        ingestThroughputBps,
+                      });
+                    } else {
+                      deal.ingestThroughputBps = ingestThroughputBps;
+                      this.dataStorageMetrics.observeIngestThroughput(providerLabels, ingestThroughputBps);
+                    }
                   }
                 }
-              }
 
-              deal.pieceCid = event.data.pieceCid.toString();
-              dealLogContext.pieceCid = event.data.pieceCid.toString();
-              this.logger.log({
-                ...dealLogContext,
-                event: "stored",
-                message: `Store completed`,
-              });
-              uploadSucceeded = true;
-              this.dataStorageMetrics.recordUploadStatus(providerLabels, "success");
-              this.dataStorageMetrics.recordOnchainStatus(providerLabels, "pending");
-              onStoredAddons.promise = this.dealAddonsService
-                .handleStored(deal, dealInput.appliedAddons, addonSignal, dealLogContext)
-                .then(() => true)
-                .catch((error) => {
-                  storedError = error;
-                  return false;
-                });
-              break;
-            }
-            case "piecesAdded":
-              this.logger.log({
-                ...dealLogContext,
-                event: "pieces_added",
-                message: "Pieces added",
-                txHash: event.data.txHash,
-              });
-              deal.piecesAddedTime = new Date();
-              if (event.data.txHash != null) {
-                deal.transactionHash = event.data.txHash as Hex;
-              } else {
-                this.logger.warn({
+                deal.pieceCid = event.data.pieceCid.toString();
+                dealLogContext.pieceCid = event.data.pieceCid.toString();
+                this.logger.log({
                   ...dealLogContext,
-                  event: "pieces_added_no_tx_hash",
-                  message: "No transaction hash found for pieces added event",
+                  event: "stored",
+                  message: `Store completed`,
                 });
+                uploadSucceeded = true;
+                this.dataStorageMetrics.recordUploadStatus(providerLabels, "success");
+                this.dataStorageMetrics.recordOnchainStatus(providerLabels, "pending");
+                onStoredAddons.promise = this.dealAddonsService
+                  .handleStored(deal, dealInput.appliedAddons, addonSignal, dealLogContext)
+                  .then(() => true)
+                  .catch((error) => {
+                    storedError = error;
+                    return false;
+                  });
+                break;
               }
-              deal.status = DealStatus.PIECE_ADDED;
-              if (deal.uploadEndTime) {
-                this.dataStorageMetrics.observePieceAddedOnChainMs(
-                  providerLabels,
-                  deal.piecesAddedTime.getTime() - deal.uploadEndTime.getTime(),
-                );
-              }
-              break;
-            case "piecesConfirmed":
-              this.logger.log({
-                ...dealLogContext,
-                event: "pieces_confirmed",
-                message: "Pieces confirmed",
-                pieceIds: event.data.pieceIds,
-              });
-              if (event.data.pieceIds.length > 1) {
-                this.logger.warn({
+              case "piecesAdded":
+                this.logger.log({
                   ...dealLogContext,
-                  event: "pieces_confirmed_multiple_piece_ids",
-                  message: "Expected at most one pieceId for dealbot content, received multiple",
+                  event: "pieces_added",
+                  message: "Pieces added",
+                  txHash: event.data.txHash,
+                });
+                deal.piecesAddedTime = new Date();
+                if (event.data.txHash != null) {
+                  deal.transactionHash = event.data.txHash as Hex;
+                } else {
+                  this.logger.warn({
+                    ...dealLogContext,
+                    event: "pieces_added_no_tx_hash",
+                    message: "No transaction hash found for pieces added event",
+                  });
+                }
+                deal.status = DealStatus.PIECE_ADDED;
+                if (deal.uploadEndTime) {
+                  this.dataStorageMetrics.observePieceAddedOnChainMs(
+                    providerLabels,
+                    deal.piecesAddedTime.getTime() - deal.uploadEndTime.getTime(),
+                  );
+                }
+                break;
+              case "piecesConfirmed":
+                this.logger.log({
+                  ...dealLogContext,
+                  event: "pieces_confirmed",
+                  message: "Pieces confirmed",
                   pieceIds: event.data.pieceIds,
                 });
-              }
-              if (event.data.pieceIds.length > 0) {
-                deal.pieceId = Number(event.data.pieceIds[0]);
-              }
-              deal.piecesConfirmedTime = new Date();
-              deal.status = DealStatus.PIECE_CONFIRMED;
-              deal.chainLatencyMs =
-                deal.piecesAddedTime != null
-                  ? deal.piecesConfirmedTime.getTime() - deal.piecesAddedTime.getTime()
-                  : null;
-              onchainSucceeded = true;
-              if (deal.chainLatencyMs !== null) {
-                this.dataStorageMetrics.observePieceConfirmedOnChainMs(providerLabels, deal.chainLatencyMs);
-              }
-              this.dataStorageMetrics.recordOnchainStatus(providerLabels, "success");
-              break;
-          }
-        },
-      });
+                if (event.data.pieceIds.length > 1) {
+                  this.logger.warn({
+                    ...dealLogContext,
+                    event: "pieces_confirmed_multiple_piece_ids",
+                    message: "Expected at most one pieceId for dealbot content, received multiple",
+                    pieceIds: event.data.pieceIds,
+                  });
+                }
+                if (event.data.pieceIds.length > 0) {
+                  deal.pieceId = Number(event.data.pieceIds[0]);
+                }
+                deal.piecesConfirmedTime = new Date();
+                deal.status = DealStatus.PIECE_CONFIRMED;
+                deal.chainLatencyMs =
+                  deal.piecesAddedTime != null
+                    ? deal.piecesConfirmedTime.getTime() - deal.piecesAddedTime.getTime()
+                    : null;
+                onchainSucceeded = true;
+                if (deal.chainLatencyMs !== null) {
+                  this.dataStorageMetrics.observePieceConfirmedOnChainMs(providerLabels, deal.chainLatencyMs);
+                }
+                this.dataStorageMetrics.recordOnchainStatus(providerLabels, "success");
+                break;
+            }
+          },
+        }),
+        signal,
+      );
       signal?.throwIfAborted();
       const pieceCid = deal.pieceCid;
       const uploadStartTime = deal.uploadStartTime;
@@ -614,6 +619,7 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
         this.dataStorageMetrics.observeCheckDuration(providerLabels, checkDurationMs);
       }
       this.dataStorageMetrics.recordDataStorageStatus(providerLabels, "success");
+      dataStorageStatusEmitted = true;
 
       this.logger.log({
         ...dealLogContext,
@@ -657,7 +663,10 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
         this.retrievalMetrics.recordStatus(providerLabels, failureStatus);
         retrievalStatusEmitted = true;
       }
-      this.dataStorageMetrics.recordDataStorageStatus(providerLabels, failureStatus);
+      if (!dataStorageStatusEmitted) {
+        this.dataStorageMetrics.recordDataStorageStatus(providerLabels, failureStatus);
+        dataStorageStatusEmitted = true;
+      }
 
       throw error;
     } finally {

--- a/apps/backend/src/jobs/jobs.service.spec.ts
+++ b/apps/backend/src/jobs/jobs.service.spec.ts
@@ -136,7 +136,10 @@ describe("JobsService schedule rows", () => {
         pgbossLocalConcurrency: 9,
         pgbossSchedulerEnabled: true,
         workerPollSeconds: 60,
+        dealJobTimeoutSeconds: 360,
+        retrievalJobTimeoutSeconds: 60,
         dataSetCreationJobTimeoutSeconds: 300,
+        shutdownFinalScrapeDelaySeconds: 35,
         pieceCleanupPerSpPerHour: 1,
         maxPieceCleanupRuntimeSeconds: 300,
       } as IConfig["jobs"],
@@ -1481,5 +1484,109 @@ describe("JobsService schedule rows", () => {
     }
 
     expect(storageProviderRepositoryMock.findOne).not.toHaveBeenCalled();
+  });
+
+  describe("onApplicationShutdown drain", () => {
+    type BossMock = {
+      stop: ReturnType<typeof vi.fn>;
+      off: ReturnType<typeof vi.fn>;
+    };
+
+    const attachMockBoss = (): BossMock => {
+      const bossMock: BossMock = {
+        stop: vi.fn(async () => undefined),
+        off: vi.fn(),
+      };
+      (service as unknown as { boss: BossMock | null }).boss = bossMock;
+      return bossMock;
+    };
+
+    it("calls boss.stop with explicit graceful timeout derived from the longest job timeout", async () => {
+      vi.useFakeTimers();
+      const bossMock = attachMockBoss();
+
+      const shutdownPromise = service.onApplicationShutdown();
+      await vi.advanceTimersByTimeAsync(35_001);
+      await shutdownPromise;
+
+      // Defaults: deal=360, retrieval=60, dataSetCreation=300, pullCheck=300 → max=360 → +60s buffer
+      expect(bossMock.stop).toHaveBeenCalledTimes(1);
+      expect(bossMock.stop).toHaveBeenCalledWith({ graceful: true, timeout: 420_000 });
+    });
+
+    it("picks the longest timeout across all job types, including pullCheck under pullPiece", async () => {
+      vi.useFakeTimers();
+      const overriddenJobs = {
+        ...baseConfigValues.jobs,
+        dealJobTimeoutSeconds: 120,
+        retrievalJobTimeoutSeconds: 60,
+        dataSetCreationJobTimeoutSeconds: 120,
+      } as IConfig["jobs"];
+      const overriddenPullPiece = {
+        ...baseConfigValues.pullPiece,
+        pullCheckJobTimeoutSeconds: 600,
+      } as IConfig["pullPiece"];
+      baseConfigValues = {
+        ...baseConfigValues,
+        jobs: overriddenJobs,
+        pullPiece: overriddenPullPiece,
+      };
+      configService = {
+        get: vi.fn((key: keyof IConfig) => baseConfigValues[key]),
+      } as unknown as JobsServiceDeps[0];
+      service = buildService({ configService });
+      const bossMock = attachMockBoss();
+
+      const shutdownPromise = service.onApplicationShutdown();
+      await vi.advanceTimersByTimeAsync(35_001);
+      await shutdownPromise;
+
+      // pullCheck wins at 600s, plus 60s buffer
+      expect(bossMock.stop).toHaveBeenCalledWith({ graceful: true, timeout: 660_000 });
+    });
+
+    it("holds the process for SHUTDOWN_FINAL_SCRAPE_DELAY_SECONDS after drain", async () => {
+      vi.useFakeTimers();
+      const bossMock = attachMockBoss();
+
+      const shutdownPromise = service.onApplicationShutdown();
+
+      // boss.stop is awaited before the sleep, so let it resolve first.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(bossMock.stop).toHaveBeenCalledTimes(1);
+
+      // Now the sleep is pending. Advance just under the configured delay (35_000ms).
+      await vi.advanceTimersByTimeAsync(34_999);
+      // Race the promise against a microtask to confirm it hasn't resolved yet.
+      const settled = await Promise.race([shutdownPromise.then(() => "done"), Promise.resolve("pending")]);
+      expect(settled).toBe("pending");
+
+      await vi.advanceTimersByTimeAsync(2);
+      await shutdownPromise;
+    });
+
+    it("skips the post-drain sleep when shutdownFinalScrapeDelaySeconds is 0", async () => {
+      vi.useFakeTimers();
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      baseConfigValues = {
+        ...baseConfigValues,
+        jobs: {
+          ...baseConfigValues.jobs,
+          shutdownFinalScrapeDelaySeconds: 0,
+        } as IConfig["jobs"],
+      };
+      configService = {
+        get: vi.fn((key: keyof IConfig) => baseConfigValues[key]),
+      } as unknown as JobsServiceDeps[0];
+      service = buildService({ configService });
+      const setTimeoutCallsBefore = setTimeoutSpy.mock.calls.length;
+      attachMockBoss();
+
+      await service.onApplicationShutdown();
+
+      // No additional setTimeout calls from the post-drain hold.
+      expect(setTimeoutSpy.mock.calls.length).toBe(setTimeoutCallsBefore);
+    });
   });
 });

--- a/apps/backend/src/jobs/jobs.service.ts
+++ b/apps/backend/src/jobs/jobs.service.ts
@@ -192,8 +192,38 @@ export class JobsService implements OnModuleInit, OnApplicationShutdown {
         this.boss.off("error", this.bossErrorHandler);
         this.bossErrorHandler = undefined;
       }
-      await this.boss.stop();
+      /**
+       * pg-boss `stop()` default timeout is 30s, shorter than any of our per-job timeouts.
+       * Pass an explicit timeout that exceeds the longest job timeout so active handlers
+       * can finish (or hit their per-job AbortController) before pg-boss force-fails
+       * them via `failWip()`.
+       */
+      const jobs = this.configService.get("jobs");
+      const longestJobTimeoutSec = Math.max(
+        jobs.dealJobTimeoutSeconds,
+        jobs.retrievalJobTimeoutSeconds,
+        jobs.dataSetCreationJobTimeoutSeconds,
+        jobs.pullCheckJobTimeoutSeconds,
+      );
+      const stopTimeoutMs = (longestJobTimeoutSec + 60) * 1000;
+      await this.boss.stop({ graceful: true, timeout: stopTimeoutMs });
       this.boss = null;
+
+      /**
+       * Hold the process alive past one ServiceMonitor scrape interval so
+       * Prometheus captures the terminal counter increments emitted during drain.
+       * Without this delay, the pod exits before its next scrape and the in-memory
+       * counter deltas die with it, leaving `pending` rows without matching terminals.
+       */
+      const finalScrapeDelayMs = jobs.shutdownFinalScrapeDelaySeconds * 1000;
+      if (finalScrapeDelayMs > 0) {
+        this.logger.log({
+          event: "pgboss_post_drain_scrape_hold",
+          message: "Holding process for final Prometheus scrape after drain",
+          delaySeconds: jobs.shutdownFinalScrapeDelaySeconds,
+        });
+        await new Promise((resolve) => setTimeout(resolve, finalScrapeDelayMs));
+      }
     }
   }
 

--- a/apps/backend/src/jobs/jobs.service.ts
+++ b/apps/backend/src/jobs/jobs.service.ts
@@ -199,11 +199,12 @@ export class JobsService implements OnModuleInit, OnApplicationShutdown {
        * them via `failWip()`.
        */
       const jobs = this.configService.get("jobs");
+      const pullPiece = this.configService.get("pullPiece");
       const longestJobTimeoutSec = Math.max(
         jobs.dealJobTimeoutSeconds,
         jobs.retrievalJobTimeoutSeconds,
         jobs.dataSetCreationJobTimeoutSeconds,
-        jobs.pullCheckJobTimeoutSeconds,
+        pullPiece.pullCheckJobTimeoutSeconds,
       );
       const stopTimeoutMs = (longestJobTimeoutSec + 60) * 1000;
       await this.boss.stop({ graceful: true, timeout: stopTimeoutMs });

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -11,7 +11,7 @@ This document provides a comprehensive guide to all environment variables used b
 | [Blockchain](#blockchain-configuration)   | `NETWORK`, `RPC_URL`, `WALLET_ADDRESS`, `WALLET_PRIVATE_KEY`, `SESSION_KEY_PRIVATE_KEY`, `CHECK_DATASET_CREATION_FEES`, `USE_ONLY_APPROVED_PROVIDERS`, `PDP_SUBGRAPH_ENDPOINT` |
 | [Dataset Versioning](#dataset-versioning) | `DEALBOT_DATASET_VERSION`                                                                                                                                    |
 | [Scheduling](#scheduling-configuration)   | `PROVIDERS_REFRESH_INTERVAL_SECONDS`, `DATA_RETENTION_POLL_INTERVAL_SECONDS`, `DEALBOT_MAINTENANCE_WINDOWS_UTC`, `DEALBOT_MAINTENANCE_WINDOW_MINUTES`                                                                                                                                 |
-| [Jobs (pg-boss)](#jobs-pg-boss)           | `DEALBOT_PGBOSS_SCHEDULER_ENABLED`, `DEALBOT_PGBOSS_POOL_MAX`, `DEALS_PER_SP_PER_HOUR`, `DATASET_CREATIONS_PER_SP_PER_HOUR`, `RETRIEVALS_PER_SP_PER_HOUR`,  `JOB_SCHEDULER_POLL_SECONDS`, `JOB_WORKER_POLL_SECONDS`, `PG_BOSS_LOCAL_CONCURRENCY`, `JOB_CATCHUP_MAX_ENQUEUE`, `JOB_SCHEDULE_PHASE_SECONDS`, `JOB_ENQUEUE_JITTER_SECONDS`, `DEAL_JOB_TIMEOUT_SECONDS`, `RETRIEVAL_JOB_TIMEOUT_SECONDS`, `IPFS_BLOCK_FETCH_CONCURRENCY` |
+| [Jobs (pg-boss)](#jobs-pg-boss)           | `DEALBOT_PGBOSS_SCHEDULER_ENABLED`, `DEALBOT_PGBOSS_POOL_MAX`, `DEALS_PER_SP_PER_HOUR`, `DATASET_CREATIONS_PER_SP_PER_HOUR`, `RETRIEVALS_PER_SP_PER_HOUR`,  `JOB_SCHEDULER_POLL_SECONDS`, `JOB_WORKER_POLL_SECONDS`, `PG_BOSS_LOCAL_CONCURRENCY`, `JOB_CATCHUP_MAX_ENQUEUE`, `JOB_SCHEDULE_PHASE_SECONDS`, `JOB_ENQUEUE_JITTER_SECONDS`, `DEAL_JOB_TIMEOUT_SECONDS`, `RETRIEVAL_JOB_TIMEOUT_SECONDS`, `SHUTDOWN_FINAL_SCRAPE_DELAY_SECONDS`, `IPFS_BLOCK_FETCH_CONCURRENCY` |
 | [Dataset](#dataset-configuration)         | `DEALBOT_LOCAL_DATASETS_PATH`, `RANDOM_PIECE_SIZES`                                                                                                          |
 | [ClickHouse](#clickhouse-configuration)   | `CLICKHOUSE_URL`, `CLICKHOUSE_BATCH_SIZE`, `CLICKHOUSE_FLUSH_INTERVAL_MS`, `DEALBOT_PROBE_LOCATION`          |
 | [Timeouts](#timeout-configuration)        | `CONNECT_TIMEOUT_MS`, `HTTP_REQUEST_TIMEOUT_MS`, `HTTP2_REQUEST_TIMEOUT_MS`, `IPNI_VERIFICATION_TIMEOUT_MS`, `IPNI_VERIFICATION_POLLING_MS`                   |
@@ -807,6 +807,25 @@ Use this to stagger multiple dealbot deployments that are not sharing a database
 - Decrease to detect and fail stuck retrievals faster
 
 **Note**: This is independent of HTTP-level timeouts. The job timeout enforces end-to-end execution time of a Retrieval Check job.
+
+---
+
+### `SHUTDOWN_FINAL_SCRAPE_DELAY_SECONDS`
+
+- **Type**: `number`
+- **Required**: No
+- **Default**: `35`
+- **Minimum**: `0`
+- **Enforced**: Yes (config validation)
+
+**Role**: Seconds the worker process holds itself alive after pg-boss drain finishes, so Prometheus captures the terminal counter increments emitted during shutdown. Without this hold, the pod exits before its next scrape and the in-memory counter deltas die with it, leaving `dataStorageStatus{value=pending}` rows without matching `success` / `failure.*` increments.
+
+**When to update**:
+
+- Increase if the ServiceMonitor scrape interval is longer than 30 seconds (set this to `scrape_interval + 5` for headroom)
+- Decrease to `0` to disable the hold (only safe if metrics are sourced elsewhere, e.g., a DB reconciler)
+
+**Note**: This value also constrains the deployment's `terminationGracePeriodSeconds`. The pod's total grace must cover the longest job timeout + pg-boss stop buffer + this delay. The default 480-second grace assumes default values across all three.
 
 ---
 ### `IPFS_BLOCK_FETCH_CONCURRENCY`


### PR DESCRIPTION
## What changed

Two related fixes that close the gap between in-flight deal jobs and graceful worker shutdown.

**Abort signal reaches `executeUpload`.** The deal-creation path called `executeUpload` without passing the per-job `AbortController` signal, so the 360s `dealJobTimeoutSeconds` could fire without interrupting a stalled upload. The call now mirrors the dataset-creation path: wrapped in `awaitWithAbort` and `signal` passed inside `UploadExecutionOptions`. A hung upload now rejects within the configured job timeout.

**Double `dataStorageStatus` emit guard.** If `postProcessDeal` threw after the success metric was recorded, the outer catch re-emitted `failure.*` for the same deal, inflating failure counts. A `dataStorageStatusEmitted` flag (matching the existing `retrievalStatusEmitted` pattern) prevents the duplicate emit.

**Graceful pg-boss drain.** `boss.stop()` was called with no options, which capped drain at the pg-boss default of 30s, far shorter than `dealJobTimeoutSeconds`. The shutdown handler now:

- Passes `{ graceful: true, timeout: longestJobTimeoutSec + 60s }` so handlers can reach terminal state.
- Sleeps for `SHUTDOWN_FINAL_SCRAPE_DELAY_SECONDS` (default 35s) after drain, letting Prometheus capture the terminal counter increments before the process exits.

Pairs with FilOzone/infra#208, which bumps `terminationGracePeriodSeconds` and adds `publishNotReadyAddresses: true` on the worker Service.

## How to verify

```bash
pnpm --filter dealbot-backend test
pnpm --filter dealbot-backend exec tsc --noEmit
pnpm exec biome check apps/backend/src/deal/deal.service.ts apps/backend/src/jobs/jobs.service.ts
```

After deploying alongside the infra PR, roll the worker Deployment in staging and confirm:

- No deals left in `uploaded` / `piece_added` / `piece_confirmed` after rollout completes.
- `dataStorageStatus{value=pending}` counter increments are matched by `success` or `failure.*` over the rollout window.

## Notes / risks

- The doc for `SHUTDOWN_FINAL_SCRAPE_DELAY_SECONDS` calls out the relationship with `terminationGracePeriodSeconds`. Operators tuning either need to keep them in sync.
- Drain extends pod termination from ~30s to up to ~480s. Argo / k8s rollout dashboards will show longer terminating states; this is expected.