### PR TITLE
feat(subgraph): track payment-active state for cheaper anon-retrieval queries

### DIFF
--- a/apps/subgraph/schema.graphql
+++ b/apps/subgraph/schema.graphql
@@ -19,10 +19,11 @@ type DataSet @entity(immutable: false) {
   id: Bytes! # setId
   setId: BigInt!
   owner: Provider!
-  # True iff the dataset has not been deleted (PDPVerifier.DataSetDeleted)
-  # and the FWSS service has not been terminated (FWSS.ServiceTerminated).
-  # Note: PDPPaymentTerminated does NOT affect this flag; clients compare
-  # pdpPaymentEndEpoch to current epoch themselves.
+  # Dataset existence + service-level state.
+  #   true  — dataset exists on PDPVerifier and the FWSS service is serving it.
+  #   false — PDPVerifier.DataSetDeleted or FWSS.ServiceTerminated has fired.
+  # Orthogonal to `isPaymentActive`: payment-rail termination does NOT touch
+  # this flag. Queries that want "currently served AND paid" must AND both flags.
   isActive: Boolean!
   status: DataSetStatus!
   # Block number of next deadline, 0 if not set. Dealbot filters on this
@@ -45,8 +46,18 @@ type DataSet @entity(immutable: false) {
 
   # Populated by FWSS.PDPPaymentTerminated handler.
   # May be in the past (already terminated) or future (terminating).
-  # Does NOT flip isActive — clients compare to current epoch.
+  # Retained for informational / backwards-compatible use; clients SHOULD
+  # filter on `isPaymentActive` rather than comparing this to current epoch.
   pdpPaymentEndEpoch: BigInt
+
+  # PDP payment-rail state.
+  #   true  — the SP is currently being paid for PDP on this dataset.
+  #   false — payment has terminated (`pdpPaymentEndEpoch` reached, or service
+  #           terminated, since payment cannot resume without the service).
+  # Orthogonal to `isActive`: a dataset can have its payment rail end while the
+  # service is still active (`isActive: true, isPaymentActive: false`). Queries
+  # that want "currently served AND paid" must AND both flags.
+  isPaymentActive: Boolean!
 
   # Block timestamp at which this DataSet was first created. Set once on
   # the creating event (whichever of FWSS.DataSetCreated or
@@ -79,4 +90,16 @@ type Root @entity(immutable: false) {
   sampleKey: Bytes!
 
   proofSet: DataSet!
+}
+
+# Bucket of DataSet IDs whose PDP payment terminates at a specific epoch.
+# Looked up O(1) by id (the epoch encoded as bytes) inside the block handler
+# attached to the FWSS data source. Populated by handleFwssPdpPaymentTerminated
+# when endEpoch > current block; consumed and removed by handleBlock when the
+# chain reaches that epoch. ServiceTerminated also unschedules entries when
+# it fires before the epoch is reached.
+type PendingPaymentTermination @entity(immutable: false) {
+  id: Bytes! # UTF-8 of the epoch's decimal string (see fwss.ts)
+  epoch: BigInt!
+  dataSetIds: [Bytes!]!
 }

--- a/apps/subgraph/src/fwss.ts
+++ b/apps/subgraph/src/fwss.ts
@@ -1,4 +1,4 @@
-import { BigInt, log } from "@graphprotocol/graph-ts";
+import { BigInt, Bytes, ethereum, log, store } from "@graphprotocol/graph-ts";
 import {
   DataSetCreated as DataSetCreatedEvent,
   DataSetServiceProviderChanged as DataSetServiceProviderChangedEvent,
@@ -6,8 +6,14 @@ import {
   PieceAdded as PieceAddedEvent,
   ServiceTerminated as ServiceTerminatedEvent,
 } from "../generated/FilecoinWarmStorageService/FilecoinWarmStorageService";
-import { DataSet, Root } from "../generated/schema";
-import { arrayContains, extractMetadataValue, getProofSetEntityId, getRootEntityId } from "./helpers";
+import { DataSet, PendingPaymentTermination, Root } from "../generated/schema";
+import {
+  arrayContains,
+  extractMetadataValue,
+  getProofSetEntityId,
+  getRootEntityId,
+  getBucketId,
+} from "./helpers";
 import { DataSetStatus } from "./types";
 
 // ---- Handlers -------------------------------------------------------------
@@ -28,6 +34,7 @@ export function handleFwssDataSetCreated(event: DataSetCreatedEvent): void {
     // PDPVerifier-level non-null defaults; handleDataSetCreated will overwrite.
     ds.owner = event.params.serviceProvider;
     ds.isActive = true;
+    ds.isPaymentActive = true;
     ds.status = DataSetStatus.EMPTY;
     ds.nextDeadline = BigInt.zero();
     ds.maxProvingPeriod = BigInt.zero();
@@ -63,6 +70,12 @@ export function handleFwssServiceTerminated(event: ServiceTerminatedEvent): void
   }
 
   ds.isActive = false;
+  ds.isPaymentActive = false;
+  const scheduledEpoch = ds.pdpPaymentEndEpoch;
+  if (scheduledEpoch !== null) {
+    unschedulePaymentTermination(ds.id, scheduledEpoch);
+  }
+
   ds.save();
 }
 
@@ -73,7 +86,27 @@ export function handleFwssPdpPaymentTerminated(event: PDPPaymentTerminatedEvent)
     return;
   }
 
+  const previousEpoch = ds.pdpPaymentEndEpoch;
+  if (previousEpoch !== null && previousEpoch.notEqual(event.params.endEpoch)) {
+    unschedulePaymentTermination(ds.id, previousEpoch);
+  }
+
   ds.pdpPaymentEndEpoch = event.params.endEpoch;
+
+  if (event.params.endEpoch.le(event.block.number)) {
+    // Termination epoch already reached (or in the past). Flip immediately —
+    // no point scheduling a bucket for a block the chain has already passed.
+    ds.isPaymentActive = false;
+  } else {
+    // Payment is flowing until `endEpoch`. This covers the re-extension case
+    // where a prior termination's epoch already elapsed (isPaymentActive was
+    // flipped false by the block handler) and a new PDPPaymentTerminated
+    // pushes the end into the future — the dataset is paying again until
+    // that new epoch. The block handler at endEpoch will flip back to false.
+    ds.isPaymentActive = true;
+    schedulePaymentTermination(ds.id, event.params.endEpoch);
+  }
+
   ds.save();
 }
 
@@ -88,4 +121,100 @@ export function handleFwssDataSetServiceProviderChanged(event: DataSetServicePro
 
   ds.fwssServiceProvider = event.params.newServiceProvider;
   ds.save();
+}
+
+/**
+ * Block handler: flip `isPaymentActive` to false on every DataSet whose
+ * `pdpPaymentEndEpoch` equals the current block. In the steady state this
+ * is a single bucket load returning null, so the per-block cost is O(1).
+ */
+export function handleBlock(block: ethereum.Block): void {
+  const bucketId = getBucketId(block.number);
+  const bucket = PendingPaymentTermination.load(bucketId);
+  if (bucket == null) {
+    return;
+  }
+
+  const ids = bucket.dataSetIds;
+  for (let i = 0; i < ids.length; i++) {
+    const ds = DataSet.load(ids[i]);
+    if (ds == null) {
+      continue;
+    }
+
+    if (ds.pdpPaymentEndEpoch === null) {
+      continue;
+    }
+
+    if ((ds.pdpPaymentEndEpoch as BigInt).notEqual(block.number)) {
+      continue;
+    }
+
+    ds.isPaymentActive = false;
+    ds.save();
+  }
+
+  store.remove("PendingPaymentTermination", bucketId.toHexString());
+}
+
+// ---- Pending-termination bucket helpers -----------------------------------
+
+/**
+ * Append `dataSetId` to the bucket for `epoch` so that `handleBlock` can flip
+ * its `isPaymentActive` when the chain reaches that block. Creates the bucket
+ * entity on first insert. Idempotent: if `dataSetId` is already in the bucket,
+ * returns without re-saving (avoids redundant store writes from duplicate
+ * event replays).
+ */
+function schedulePaymentTermination(dataSetId: Bytes, epoch: BigInt): void {
+  const bucketId = getBucketId(epoch);
+
+  let bucket = PendingPaymentTermination.load(bucketId);
+  if (bucket == null) {
+    bucket = new PendingPaymentTermination(bucketId);
+    bucket.epoch = epoch;
+    bucket.dataSetIds = [];
+  }
+
+  const ids = bucket.dataSetIds;
+  for (let i = 0; i < ids.length; i++) {
+    if (ids[i].equals(dataSetId)) {
+      // Already scheduled — re-saving the bucket would be a no-op.
+      return;
+    }
+  }
+  ids.push(dataSetId);
+  bucket.dataSetIds = ids;
+  bucket.save();
+}
+
+/**
+ * Remove `dataSetId` from the bucket for `epoch`, deleting the bucket entity
+ * entirely once it goes empty so the steady-state bucket store doesn't grow
+ * unboundedly. Called when a dataset is re-terminated at a different epoch or
+ * when `FWSS.ServiceTerminated` makes the prior schedule moot. No-ops if the
+ * bucket no longer exists (block handler already consumed it) — the matching
+ * `handleBlock` re-check is the safety net for that race.
+ */
+function unschedulePaymentTermination(dataSetId: Bytes, epoch: BigInt): void {
+  const bucketId = getBucketId(epoch);
+  const bucket = PendingPaymentTermination.load(bucketId);
+  if (bucket == null) {
+    return;
+  }
+
+  const filtered: Bytes[] = [];
+  for (let i = 0; i < bucket.dataSetIds.length; i++) {
+    if (!bucket.dataSetIds[i].equals(dataSetId)) {
+      filtered.push(bucket.dataSetIds[i]);
+    }
+  }
+
+  if (filtered.length == 0) {
+    store.remove("PendingPaymentTermination", bucketId.toHexString());
+    return;
+  }
+
+  bucket.dataSetIds = filtered;
+  bucket.save();
 }

--- a/apps/subgraph/src/helpers.ts
+++ b/apps/subgraph/src/helpers.ts
@@ -10,6 +10,15 @@ export function getRootEntityId(setId: BigInt, rootId: BigInt): Bytes {
   return Bytes.fromUTF8(setId.toString() + "-" + rootId.toString());
 }
 
+// Entity id for PendingPaymentTermination buckets, keyed by termination epoch.
+// Uses the decimal string form (not Bytes.fromBigInt) because that encoding
+// is length-stable across BigInts coming from event params vs loaded from
+// the store — `Bytes.fromBigInt` returns variable-length minimal bytes that
+// can differ between the two sources for the same numeric value.
+export function getBucketId(epoch: BigInt): Bytes {
+  return Bytes.fromUTF8(epoch.toString());
+}
+
 // Uniform pseudorandom sort key for Root entities. Used by dealbot to draw
 // random pieces fairly via `orderBy: sampleKey, where: { sampleKey_gte: X }`,
 // which needs a key distributed independently of setId/rootId.

--- a/apps/subgraph/src/pdp-verifier.ts
+++ b/apps/subgraph/src/pdp-verifier.ts
@@ -41,6 +41,7 @@ export function handleDataSetCreated(event: DataSetCreatedEvent): void {
   proofSet.setId = event.params.setId;
   proofSet.owner = providerEntityId;
   proofSet.isActive = true;
+  proofSet.isPaymentActive = true;
   proofSet.status = DataSetStatus.EMPTY;
   proofSet.nextDeadline = BigInt.zero();
   proofSet.maxProvingPeriod = BigInt.zero();

--- a/apps/subgraph/subgraph.yaml
+++ b/apps/subgraph/subgraph.yaml
@@ -55,9 +55,12 @@ dataSources:
       entities:
         - DataSet
         - Root
+        - PendingPaymentTermination
       abis:
         - name: FilecoinWarmStorageService
           file: ./abis/FilecoinWarmStorageService.json
+      blockHandlers:
+        - handler: handleBlock
       eventHandlers:
         - event: DataSetCreated(indexed uint256,indexed
             uint256,uint256,uint256,uint256,address,address,address,string[],string[])

--- a/apps/subgraph/tests/fwss-utils.ts
+++ b/apps/subgraph/tests/fwss-utils.ts
@@ -1,5 +1,31 @@
 import { newMockEvent } from "matchstick-as";
 import { ethereum, BigInt, Address, Bytes } from "@graphprotocol/graph-ts";
+
+const DEFAULT_ADDRESS = Address.fromString("0xA16081F360e3847006dB660bae1c6d1b2e17eC2A");
+const DEFAULT_BYTES = DEFAULT_ADDRESS as Bytes;
+const DEFAULT_BIGINT = BigInt.fromI32(1);
+
+// Build an ethereum.Block with a specific block number. Matchstick's
+// `newBlock()` helper isn't exported, so reconstruct the same shape here.
+export function makeBlockAt(blockNumber: BigInt): ethereum.Block {
+  return new ethereum.Block(
+    DEFAULT_BYTES,
+    DEFAULT_BYTES,
+    DEFAULT_BYTES,
+    DEFAULT_ADDRESS,
+    DEFAULT_BYTES,
+    DEFAULT_BYTES,
+    DEFAULT_BYTES,
+    blockNumber,
+    DEFAULT_BIGINT,
+    DEFAULT_BIGINT,
+    DEFAULT_BIGINT,
+    DEFAULT_BIGINT,
+    DEFAULT_BIGINT,
+    DEFAULT_BIGINT,
+    DEFAULT_BIGINT,
+  );
+}
 import {
   DataSetCreated as FwssDataSetCreated,
   PieceAdded as FwssPieceAdded,

--- a/apps/subgraph/tests/fwss.test.ts
+++ b/apps/subgraph/tests/fwss.test.ts
@@ -1,13 +1,14 @@
 import { assert, beforeEach, clearStore, describe, test } from "matchstick-as/assembly/index";
 import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
 import {
+  handleBlock,
   handleFwssDataSetCreated,
   handleFwssDataSetServiceProviderChanged,
   handleFwssPdpPaymentTerminated,
   handleFwssPieceAdded,
   handleFwssServiceTerminated,
 } from "../src/fwss";
-import { getRootEntityId } from "../src/helpers";
+import { getRootEntityId, getBucketId } from "../src/helpers";
 import { handleDataSetCreated, handlePiecesAdded } from "../src/pdp-verifier";
 import { createDataSetCreatedEvent, createRootsAddedEvent } from "./pdp-verifier-utils";
 import {
@@ -16,6 +17,7 @@ import {
   createFwssPdpPaymentTerminatedEvent,
   createFwssPieceAddedEvent,
   createFwssServiceTerminatedEvent,
+  makeBlockAt,
 } from "./fwss-utils";
 
 const SET_ID = BigInt.fromI32(1);
@@ -204,6 +206,139 @@ describe("FWSS handlers", () => {
 
     assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "pdpPaymentEndEpoch", "12345");
     assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "isActive", "true");
+  });
+
+  test("handleFwssPdpPaymentTerminated with future endEpoch schedules the bucket and keeps isPaymentActive", () => {
+    seedDataSet();
+    // Default event block.number is 1; endEpoch=12345 is in the future.
+    const ev = createFwssPdpPaymentTerminatedEvent(SET_ID, BigInt.fromI32(12345), PDP_RAIL_ID);
+    handleFwssPdpPaymentTerminated(ev);
+
+    assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "isPaymentActive", "true");
+    const bucketId = getBucketId(BigInt.fromI32(12345)).toHexString();
+    assert.fieldEquals("PendingPaymentTermination", bucketId, "epoch", "12345");
+    assert.fieldEquals(
+      "PendingPaymentTermination",
+      bucketId,
+      "dataSetIds",
+      "[" + PROOF_SET_ENTITY_ID.toHexString() + "]",
+    );
+  });
+
+  test("handleFwssPdpPaymentTerminated with past endEpoch flips isPaymentActive immediately without scheduling", () => {
+    seedDataSet();
+    // endEpoch=0 is before the event's default block.number=1.
+    const ev = createFwssPdpPaymentTerminatedEvent(SET_ID, BigInt.zero(), PDP_RAIL_ID);
+    handleFwssPdpPaymentTerminated(ev);
+
+    assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "isPaymentActive", "false");
+    const bucketId = getBucketId(BigInt.zero()).toHexString();
+    assert.notInStore("PendingPaymentTermination", bucketId);
+  });
+
+  test("handleFwssPdpPaymentTerminated with endEpoch equal to current block flips immediately", () => {
+    seedDataSet();
+    // endEpoch == block.number (default 1): treated as already past.
+    const ev = createFwssPdpPaymentTerminatedEvent(SET_ID, BigInt.fromI32(1), PDP_RAIL_ID);
+    handleFwssPdpPaymentTerminated(ev);
+
+    assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "isPaymentActive", "false");
+    const bucketId = getBucketId(BigInt.fromI32(1)).toHexString();
+    assert.notInStore("PendingPaymentTermination", bucketId);
+  });
+
+  test("re-termination unschedules the previous bucket and reschedules under the new epoch", () => {
+    seedDataSet();
+    handleFwssPdpPaymentTerminated(createFwssPdpPaymentTerminatedEvent(SET_ID, BigInt.fromI32(100), PDP_RAIL_ID));
+    handleFwssPdpPaymentTerminated(createFwssPdpPaymentTerminatedEvent(SET_ID, BigInt.fromI32(200), PDP_RAIL_ID));
+
+    const oldBucket = getBucketId(BigInt.fromI32(100)).toHexString();
+    const newBucket = getBucketId(BigInt.fromI32(200)).toHexString();
+    assert.notInStore("PendingPaymentTermination", oldBucket);
+    assert.fieldEquals(
+      "PendingPaymentTermination",
+      newBucket,
+      "dataSetIds",
+      "[" + PROOF_SET_ENTITY_ID.toHexString() + "]",
+    );
+    assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "pdpPaymentEndEpoch", "200");
+  });
+
+  test("re-termination with a future endEpoch restores isPaymentActive after a prior termination elapsed", () => {
+    // Simulates: termination scheduled, epoch passes (flag flips false), then a
+    // new PDPPaymentTerminated pushes the end into the future. The dataset is
+    // paying again until the new epoch, so the flag must flip back to true.
+    seedDataSet();
+    handleFwssPdpPaymentTerminated(createFwssPdpPaymentTerminatedEvent(SET_ID, BigInt.fromI32(100), PDP_RAIL_ID));
+    handleBlock(makeBlockAt(BigInt.fromI32(100)));
+    assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "isPaymentActive", "false");
+
+    handleFwssPdpPaymentTerminated(createFwssPdpPaymentTerminatedEvent(SET_ID, BigInt.fromI32(500), PDP_RAIL_ID));
+
+    assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "isPaymentActive", "true");
+    assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "pdpPaymentEndEpoch", "500");
+    const newBucket = getBucketId(BigInt.fromI32(500)).toHexString();
+    assert.fieldEquals(
+      "PendingPaymentTermination",
+      newBucket,
+      "dataSetIds",
+      "[" + PROOF_SET_ENTITY_ID.toHexString() + "]",
+    );
+  });
+
+  // -- handleBlock --------------------------------------------------------
+
+  test("handleBlock flips isPaymentActive and removes the bucket at the scheduled epoch", () => {
+    seedDataSet();
+    handleFwssPdpPaymentTerminated(createFwssPdpPaymentTerminatedEvent(SET_ID, BigInt.fromI32(500), PDP_RAIL_ID));
+    assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "isPaymentActive", "true");
+
+    handleBlock(makeBlockAt(BigInt.fromI32(500)));
+
+    assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "isPaymentActive", "false");
+    const bucketId = getBucketId(BigInt.fromI32(500)).toHexString();
+    assert.notInStore("PendingPaymentTermination", bucketId);
+  });
+
+  test("handleBlock is a no-op when no bucket exists for the current block", () => {
+    seedDataSet();
+    // No PDPPaymentTerminated fired; isPaymentActive must stay true after a tick.
+    handleBlock(makeBlockAt(BigInt.fromI32(7)));
+    assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "isPaymentActive", "true");
+  });
+
+  test("handleBlock skips datasets whose pdpPaymentEndEpoch no longer matches the bucket epoch", () => {
+    // Defense in depth: if a stale bucket entry survives (re-termination races
+    // or future schema changes), the block handler re-checks the dataset's
+    // current end epoch before flipping.
+    seedDataSet();
+    handleFwssPdpPaymentTerminated(createFwssPdpPaymentTerminatedEvent(SET_ID, BigInt.fromI32(100), PDP_RAIL_ID));
+    handleFwssPdpPaymentTerminated(createFwssPdpPaymentTerminatedEvent(SET_ID, BigInt.fromI32(200), PDP_RAIL_ID));
+
+    // Firing the OLD epoch should not flip — the dataset is now scheduled for 200.
+    handleBlock(makeBlockAt(BigInt.fromI32(100)));
+    assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "isPaymentActive", "true");
+
+    // Firing the NEW epoch flips.
+    handleBlock(makeBlockAt(BigInt.fromI32(200)));
+    assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "isPaymentActive", "false");
+  });
+
+  test("handleFwssServiceTerminated also flips isPaymentActive and removes the bucket entry", () => {
+    seedDataSet();
+    handleFwssPdpPaymentTerminated(createFwssPdpPaymentTerminatedEvent(SET_ID, BigInt.fromI32(300), PDP_RAIL_ID));
+
+    handleFwssServiceTerminated(createFwssServiceTerminatedEvent(SET_ID, PROVIDER_ADDRESS));
+
+    assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "isActive", "false");
+    assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "isPaymentActive", "false");
+    const bucketId = getBucketId(BigInt.fromI32(300)).toHexString();
+    assert.notInStore("PendingPaymentTermination", bucketId);
+  });
+
+  test("DataSet is created with isPaymentActive=true by default", () => {
+    seedDataSet();
+    assert.fieldEquals("DataSet", PROOF_SET_ENTITY_ID.toHexString(), "isPaymentActive", "true");
   });
 
   test("handleFwssPdpPaymentTerminated no-ops for unknown dataSetId", () => {


### PR DESCRIPTION
The subgraph part of #579
The backend part is here https://github.com/probe-lab/dealbot/pull/12 and depends on https://github.com/FilOzone/dealbot/pull/487 to land first.

## Why

In the pending retrieval anon implementation why draw candidate pieces by running multiple attempts and then hoping that we draw a pieces whose payment hasn't terminated yet. The reason for this is that we'd need to pass the current epoch to the query to filter the result set server side which isn't available. Secondly, we'll get served the current epoch together with the query result but cannot make use of that field during the querying process so we can only apply the filter condition after we got served the data.

## What

In this PR we add a callback to the subgraph code that fires on every block (`handleBlock`) which "cleans up" all datasets that have expired at that epoch by setting a new `isPaymentActive` flag to false. The rest of the code is just bookkeeping of that flag as a response to various events.

How it is maintained:
- `PDPPaymentTerminated` with future endEpoch schedules the dataset into a `PendingPaymentTermination` bucket keyed by epoch; if endEpoch is already past, the flag flips immediately.
- A new `handleBlock` attached to the FWSS data source loads the bucket for the current block (O(1) load returning null in the steady state) and flips matching datasets to `isPaymentActive: false`.
- `ServiceTerminated` also flips the flag and unschedules from the bucket.
- Re-extension (a new PDPPaymentTerminated after a prior epoch elapsed) sets the flag back to true and reschedules.

Backwards compatible: `pdpPaymentEndEpoch` stays on the schema unchanged and is still populated. Existing clients comparing it to the current epoch keep working; new clients can use the cheaper `isPaymentActive` filter instead.

## Deployment

Deployed new version of this subgraph to:

- `calibration`: https://api.goldsky.com/api/public/project_cmppqidloyxtu01tgc9b3e3w4/subgraphs/dealbot-calibration/0.1.0/gn
- `mainnet`: https://api.goldsky.com/api/public/project_cmppqidloyxtu01tgc9b3e3w4/subgraphs/dealbot-mainnet/0.1.0/gn

I've also reset the version to `0.1.0` because I've deployed them into a new Goldsky account which I'll plan to hand over to FilOZ.