### PR TITLE
feat: store deal retrieval metrics in clickhouse

### DIFF
--- a/apps/backend/src/clickhouse/clickhouse.schema.ts
+++ b/apps/backend/src/clickhouse/clickhouse.schema.ts
@@ -101,5 +101,16 @@ export function buildMigrations(database: string): string[] {
   PRIMARY KEY (probe_location, sp_address, timestamp)
   PARTITION BY toStartOfMonth(timestamp)
   TTL toDateTime(timestamp) + INTERVAL 1 YEAR`,
+
+    // These are the flattened subcolumns of a Nested(...) column; added flattened
+    // rather than as `ADD COLUMN retrieval_checks Nested(...)` so IF NOT EXISTS stays idempotent on
+    // replay. The bare nested name may not exist as a column, the dotted subcolumns certainly do.
+    `ALTER TABLE ${database}.data_storage_checks
+        ADD COLUMN IF NOT EXISTS \`retrieval_checks.method\`             Array(LowCardinality(String)),
+        ADD COLUMN IF NOT EXISTS \`retrieval_checks.status\`             Array(LowCardinality(String)),
+        ADD COLUMN IF NOT EXISTS \`retrieval_checks.http_response_code\` Array(Nullable(UInt16)),
+        ADD COLUMN IF NOT EXISTS \`retrieval_checks.first_byte_ms\`      Array(Nullable(Float64)),
+        ADD COLUMN IF NOT EXISTS \`retrieval_checks.last_byte_ms\`       Array(Nullable(Float64)),
+        ADD COLUMN IF NOT EXISTS \`retrieval_checks.bytes_retrieved\`    Array(Nullable(UInt64))`,
   ];
 }

--- a/apps/backend/src/deal/deal.service.ts
+++ b/apps/backend/src/deal/deal.service.ts
@@ -35,7 +35,7 @@ import {
   RetrievalCheckMetrics,
 } from "../metrics-prometheus/check-metrics.service.js";
 import { RetrievalAddonsService } from "../retrieval-addons/retrieval-addons.service.js";
-import type { RetrievalConfiguration } from "../retrieval-addons/types.js";
+import type { RetrievalConfiguration, RetrievalExecutionResult } from "../retrieval-addons/types.js";
 import { WalletSdkService } from "../wallet-sdk/wallet-sdk.service.js";
 import type { PDPProviderEx } from "../wallet-sdk/wallet-sdk.types.js";
 
@@ -281,6 +281,7 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
     let retrievalStatusEmitted = false;
     let preUploadTerminated = false;
     let dataStorageStatusEmitted = false;
+    let retrievalResults: RetrievalExecutionResult[] = [];
 
     let deal: Deal;
     if (existingDealId) {
@@ -586,6 +587,7 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
         dealLogContext,
       );
       signal?.throwIfAborted();
+      retrievalResults = retrievalTest.results;
 
       this.retrievalMetrics.recordResultMetrics(retrievalTest.results, providerLabels);
       this.retrievalMetrics.recordStatus(
@@ -680,7 +682,7 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
         }
       }
       if (!preUploadTerminated) {
-        await this.saveDeal(deal, dealLogContext);
+        await this.saveDeal(deal, retrievalResults, dealLogContext);
       }
     }
   }
@@ -1086,7 +1088,11 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
     deal.pieceId = uploadResult.pieceId ?? deal.pieceId;
   }
 
-  private async saveDeal(deal: Deal, dealLogContext: DealLogContext): Promise<void> {
+  private async saveDeal(
+    deal: Deal,
+    retrievalResults: RetrievalExecutionResult[],
+    dealLogContext: DealLogContext,
+  ): Promise<void> {
     this.clickhouseService.insert("data_storage_checks", {
       timestamp: Date.now(),
       probe_location: this.clickhouseService.probeLocation,
@@ -1110,6 +1116,12 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
       ipni_verified_at: deal.ipniVerifiedAt?.getTime() ?? null,
       ipni_verified_cids_count: deal.ipniVerifiedCidsCount ?? null,
       ipni_unverified_cids_count: deal.ipniUnverifiedCidsCount ?? null,
+      "retrieval_checks.method": retrievalResults.map((r) => r.method),
+      "retrieval_checks.status": retrievalResults.map((r) => (r.success ? "success" : "failure")),
+      "retrieval_checks.http_response_code": retrievalResults.map((r) => r.metrics.statusCode || null),
+      "retrieval_checks.first_byte_ms": retrievalResults.map((r) => (r.success ? r.metrics.ttfb : null)),
+      "retrieval_checks.last_byte_ms": retrievalResults.map((r) => (r.success ? r.metrics.latency : null)),
+      "retrieval_checks.bytes_retrieved": retrievalResults.map((r) => (r.success ? r.metrics.responseSize : null)),
     });
 
     try {


### PR DESCRIPTION
# Why

The current betterstack dashboard shows the following three throughput metrics:

- Upload Throughput
- Download Throughput (dataStorage check)
- Download Throughput (retrieval check)

The data for `Download Throughput (dataStorage check)` is missing so that we cannot build a dashboard for that.

# What

This PR adds a [`Nested`](https://clickhouse.com/docs/sql-reference/data-types/nested-data-structures/nested) `retrieval_checks` column to the `data_storage_checks` table. We use a `Nested` column because dealbot support (and performs?) multiple retrieval checks (direct-sp, ipfs-pin). Having a `Nested` column allows to add more methods in the future without changing the schema.

The migration is adding the parallel arrays manually to keep the migrations idempotent (see comment in the code).