### PR TITLE
refactor: migrate dataset termination to provider-relayed flow

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -30,8 +30,8 @@
   },
   "dependencies": {
     "@clickhouse/client": "^1.11.0",
-    "@filoz/synapse-core": "0.5.2",
-    "@filoz/synapse-sdk": "0.41.0",
+    "@filoz/synapse-core": "0.7.0",
+    "@filoz/synapse-sdk": "1.0.1",
     "@ipld/car": "^5.4.2",
     "@ipld/dag-pb": "^4.1.4",
     "@nestjs/axios": "^4.0.1",

--- a/apps/backend/src/data-set-lifecycle/data-set-lifecycle.service.spec.ts
+++ b/apps/backend/src/data-set-lifecycle/data-set-lifecycle.service.spec.ts
@@ -129,7 +129,7 @@ describe("DataSetLifecycleService", () => {
       expect.objectContaining({ serviceURL: "https://sp.example.com" }),
     );
     expect(findPiece).toHaveBeenCalledWith(
-      expect.objectContaining({ serviceURL: "https://sp.example.com", pieceCid: mockPieceCid, retry: true }),
+      expect.objectContaining({ serviceURL: "https://sp.example.com", pieceCid: mockPieceCid, poll: true }),
     );
     expect(createDataSetAndAddPieces).toHaveBeenCalledWith(
       mockClient,

--- a/apps/backend/src/data-set-lifecycle/data-set-lifecycle.service.spec.ts
+++ b/apps/backend/src/data-set-lifecycle/data-set-lifecycle.service.spec.ts
@@ -10,10 +10,8 @@ vi.mock("@filoz/synapse-core/sp", () => ({
   findPiece: vi.fn(),
   createDataSetAndAddPieces: vi.fn(),
   waitForCreateDataSetAddPieces: vi.fn(),
-}));
-
-vi.mock("@filoz/synapse-core/warm-storage", () => ({
-  terminateServiceSync: vi.fn(),
+  terminateService: vi.fn(),
+  waitForTerminateService: vi.fn(),
 }));
 
 const {
@@ -23,8 +21,9 @@ const {
   findPiece,
   createDataSetAndAddPieces,
   waitForCreateDataSetAddPieces,
+  terminateService,
+  waitForTerminateService,
 } = await import("@filoz/synapse-core/sp");
-const { terminateServiceSync } = await import("@filoz/synapse-core/warm-storage");
 
 const mockClient = { account: { address: "0xwallet" } };
 
@@ -75,10 +74,21 @@ function setupWithPiecesVariantMocks() {
   });
 }
 
+function setupTerminateMocks() {
+  vi.mocked(terminateService).mockResolvedValue({ statusUrl: "https://sp.example.com/terminate/status" });
+  vi.mocked(waitForTerminateService).mockResolvedValue({
+    terminationTxHash: "0xterminate",
+    txStatus: "confirmed",
+    txSuccess: true,
+    fwssTerminated: true,
+    serviceTerminationEpoch: 100n,
+  } as any);
+}
+
 function setupAllVariantMocks() {
   setupEmptyVariantMocks();
   setupWithPiecesVariantMocks();
-  vi.mocked(terminateServiceSync).mockResolvedValue({ receipt: {} as any, event: {} as any });
+  setupTerminateMocks();
 }
 
 describe("DataSetLifecycleService", () => {
@@ -135,10 +145,20 @@ describe("DataSetLifecycleService", () => {
       expect.objectContaining({ statusUrl: "https://sp.example.com/status/2" }),
     );
 
-    // terminateServiceSync called for both data sets
-    expect(terminateServiceSync).toHaveBeenCalledTimes(2);
-    expect(terminateServiceSync).toHaveBeenCalledWith(mockClient, expect.objectContaining({ dataSetId: 42n }));
-    expect(terminateServiceSync).toHaveBeenCalledWith(mockClient, expect.objectContaining({ dataSetId: 77n }));
+    // terminateService (provider-relayed) called for both data sets, each followed by a status poll
+    expect(terminateService).toHaveBeenCalledTimes(2);
+    expect(terminateService).toHaveBeenCalledWith(
+      mockClient,
+      expect.objectContaining({ dataSetId: 42n, serviceURL: "https://sp.example.com" }),
+    );
+    expect(terminateService).toHaveBeenCalledWith(
+      mockClient,
+      expect.objectContaining({ dataSetId: 77n, serviceURL: "https://sp.example.com" }),
+    );
+    expect(waitForTerminateService).toHaveBeenCalledTimes(2);
+    expect(waitForTerminateService).toHaveBeenCalledWith(
+      expect.objectContaining({ statusUrl: "https://sp.example.com/terminate/status" }),
+    );
 
     expect(mockMetrics.recordStatus).toHaveBeenCalledOnce();
     expect(mockMetrics.recordStatus).toHaveBeenCalledWith(
@@ -171,7 +191,7 @@ describe("DataSetLifecycleService", () => {
 
   it("throws when empty variant fails even if with-pieces variant succeeds", async () => {
     setupWithPiecesVariantMocks();
-    vi.mocked(terminateServiceSync).mockResolvedValue({ receipt: {} as any, event: {} as any });
+    setupTerminateMocks();
     vi.mocked(createDataSet).mockRejectedValue(new Error("empty variant: SP unreachable"));
 
     await expect(service.runLifecycleCheck("0xsp", { dealbotLifecycleCheck: "nonce-partial-1" })).rejects.toThrow(
@@ -187,7 +207,7 @@ describe("DataSetLifecycleService", () => {
 
   it("throws when with-pieces variant fails even if empty variant succeeds", async () => {
     setupEmptyVariantMocks();
-    vi.mocked(terminateServiceSync).mockResolvedValue({ receipt: {} as any, event: {} as any });
+    setupTerminateMocks();
     vi.mocked(uploadPieceStreaming).mockRejectedValue(new Error("with-pieces variant: upload failed"));
 
     await expect(service.runLifecycleCheck("0xsp", { dealbotLifecycleCheck: "nonce-partial-2" })).rejects.toThrow(
@@ -220,14 +240,14 @@ describe("DataSetLifecycleService", () => {
 
   it("records failure.other for empty variant when createDataSet rejects", async () => {
     setupWithPiecesVariantMocks();
-    vi.mocked(terminateServiceSync).mockResolvedValue({ receipt: {} as any, event: {} as any });
+    setupTerminateMocks();
     vi.mocked(createDataSet).mockRejectedValue(new Error("SP unreachable"));
 
     await expect(service.runLifecycleCheck("0xsp", { dealbotLifecycleCheck: "nonce-e-1" })).rejects.toThrow(
       "SP unreachable",
     );
 
-    expect(terminateServiceSync).toHaveBeenCalledOnce(); // only with-pieces succeeded
+    expect(terminateService).toHaveBeenCalledOnce(); // only with-pieces succeeded
     expect(mockMetrics.recordStatus).toHaveBeenCalledOnce();
     expect(mockMetrics.recordStatus).toHaveBeenCalledWith(
       expect.objectContaining({ checkType: "dataSetLifecycleCheck" }),
@@ -237,9 +257,9 @@ describe("DataSetLifecycleService", () => {
 
   it("records failure.other for empty variant when termination fails after creation", async () => {
     setupAllVariantMocks();
-    vi.mocked(terminateServiceSync)
+    vi.mocked(terminateService)
       .mockRejectedValueOnce(new Error("terminate failed"))
-      .mockResolvedValueOnce({ receipt: {} as any, event: {} as any });
+      .mockResolvedValueOnce({ statusUrl: "https://sp.example.com/terminate/status" });
 
     await expect(service.runLifecycleCheck("0xsp", { dealbotLifecycleCheck: "nonce-e-2" })).rejects.toThrow(
       "terminate failed",
@@ -254,7 +274,7 @@ describe("DataSetLifecycleService", () => {
 
   it("records failure.other for with-pieces variant when findPiece rejects", async () => {
     setupEmptyVariantMocks();
-    vi.mocked(terminateServiceSync).mockResolvedValue({ receipt: {} as any, event: {} as any });
+    setupTerminateMocks();
     vi.mocked(uploadPieceStreaming).mockResolvedValue({ pieceCid: mockPieceCid as any, size: 256 });
     vi.mocked(findPiece).mockRejectedValue(new Error("piece not found"));
 
@@ -272,7 +292,7 @@ describe("DataSetLifecycleService", () => {
 
   it("records failure.other for with-pieces variant when createDataSetAndAddPieces rejects", async () => {
     setupEmptyVariantMocks();
-    vi.mocked(terminateServiceSync).mockResolvedValue({ receipt: {} as any, event: {} as any });
+    setupTerminateMocks();
     vi.mocked(uploadPieceStreaming).mockResolvedValue({ pieceCid: mockPieceCid as any, size: 256 });
     vi.mocked(findPiece).mockResolvedValue(mockPieceCid as any);
     vi.mocked(createDataSetAndAddPieces).mockRejectedValue(new Error("on-chain create failed"));
@@ -291,8 +311,8 @@ describe("DataSetLifecycleService", () => {
 
   it("records failure.other for with-pieces variant when termination fails after creation", async () => {
     setupAllVariantMocks();
-    vi.mocked(terminateServiceSync)
-      .mockResolvedValueOnce({ receipt: {} as any, event: {} as any })
+    vi.mocked(terminateService)
+      .mockResolvedValueOnce({ statusUrl: "https://sp.example.com/terminate/status" })
       .mockRejectedValueOnce(new Error("terminate failed"));
 
     await expect(service.runLifecycleCheck("0xsp", { dealbotLifecycleCheck: "nonce-wp-3" })).rejects.toThrow(

--- a/apps/backend/src/data-set-lifecycle/data-set-lifecycle.service.ts
+++ b/apps/backend/src/data-set-lifecycle/data-set-lifecycle.service.ts
@@ -2,11 +2,13 @@ import {
   createDataSet,
   createDataSetAndAddPieces,
   findPiece,
+  type TerminateServiceStatusSuccess,
+  terminateService,
   uploadPieceStreaming,
   waitForCreateDataSet,
   waitForCreateDataSetAddPieces,
+  waitForTerminateService,
 } from "@filoz/synapse-core/sp";
-import { terminateServiceSync } from "@filoz/synapse-core/warm-storage";
 import { Injectable, Logger } from "@nestjs/common";
 import { awaitWithAbort } from "../common/abort-utils.js";
 import { type ProviderJobContext, toStructuredError } from "../common/logging.js";
@@ -22,6 +24,24 @@ type LifecycleBaseLogContext = {
   providerId: bigint;
   providerName: string;
 };
+
+/**
+ * Provider-relayed termination as a single call: sign + POST the EIP-712
+ * authorization (`terminateService`) then poll until the SP confirms it on-chain
+ * (`waitForTerminateService`). Replaces the old warm-storage `terminateServiceSync`,
+ * which submitted the tx directly — a path that reverts for Safe-multisig payers
+ * because the session-key signer is never the on-chain msg.sender (#546).
+ */
+async function terminateServiceSync(
+  client: SynapseViemClient,
+  options: { dataSetId: bigint; serviceURL: string; onHash?: (hash: `0x${string}`) => void },
+): Promise<TerminateServiceStatusSuccess> {
+  const { statusUrl } = await terminateService(client, {
+    dataSetId: options.dataSetId,
+    serviceURL: options.serviceURL,
+  });
+  return waitForTerminateService({ statusUrl, onHash: options.onHash });
+}
 
 @Injectable()
 export class DataSetLifecycleService {
@@ -160,6 +180,7 @@ export class DataSetLifecycleService {
       await awaitWithAbort(
         terminateServiceSync(client, {
           dataSetId,
+          serviceURL: providerInfo.pdp.serviceURL,
           onHash: (hash) => {
             this.logger.log({
               event: "dataset_lifecycle_check_terminating",
@@ -296,6 +317,7 @@ export class DataSetLifecycleService {
       await awaitWithAbort(
         terminateServiceSync(client, {
           dataSetId,
+          serviceURL: providerInfo.pdp.serviceURL,
           onHash: (hash) => {
             this.logger.log({
               event: "dataset_with_pieces_lifecycle_check_terminating",

--- a/apps/backend/src/data-set-lifecycle/data-set-lifecycle.service.ts
+++ b/apps/backend/src/data-set-lifecycle/data-set-lifecycle.service.ts
@@ -269,7 +269,7 @@ export class DataSetLifecycleService {
         findPiece({
           serviceURL: providerInfo.pdp.serviceURL,
           pieceCid,
-          retry: true,
+          poll: true,
           signal,
         }),
         signal,

--- a/apps/backend/src/deal/deal.service.spec.ts
+++ b/apps/backend/src/deal/deal.service.spec.ts
@@ -121,7 +121,6 @@ describe("DealService", () => {
   const mockWarmStorageService = {
     validateDataSet: vi.fn().mockResolvedValue(undefined),
     getDataSet: vi.fn().mockResolvedValue({ pdpEndEpoch: 0n }),
-    terminateDataSet: vi.fn().mockResolvedValue("0xhash"),
   };
   // Default: dataset is live. Tests that exercise the terminated path override per-call.
   const mockDatasetLivenessService = {
@@ -1364,17 +1363,14 @@ describe("DealService", () => {
       vi.spyOn(mockWalletSdkService, "getProviderInfo").mockReturnValue({ id: 1n, name: "sp" } as any);
     });
 
-    it("terminates, awaits receipt, polls pdpEndEpoch, and marks affected deals cleaned up in one transaction", async () => {
-      const terminateMock = vi.fn().mockResolvedValue("0xhash");
-      const waitForReceiptMock = vi.fn().mockResolvedValue({ status: "success" });
+    it("terminates via provider relay and marks affected deals cleaned up in one transaction", async () => {
+      const terminateMock = vi.fn().mockResolvedValue({ txHash: "0xhash", dataSetId: 9n, endEpoch: 12345n });
       const synapseMock = {
-        storage: { terminateDataSet: terminateMock },
-        client: { waitForTransactionReceipt: waitForReceiptMock },
+        storage: { terminateService: terminateMock },
       };
       vi.spyOn(service as any, "createSynapseInstance").mockImplementation(() => synapseMock as unknown as Synapse);
 
       mockWarmStorageService.getDataSet.mockResolvedValueOnce({ pdpEndEpoch: 0n });
-      mockWarmStorageService.getDataSet.mockResolvedValueOnce({ pdpEndEpoch: 12345n });
 
       const updateFn = vi.fn().mockResolvedValue({ affected: 2 });
       const transactionMock = vi.fn(async (cb: any) => cb({ getRepository: () => ({ update: updateFn }) }));
@@ -1383,10 +1379,9 @@ describe("DealService", () => {
         value: { transaction: transactionMock },
       });
 
-      const result = await service.repairTerminatedDataSet("0xaaa", 9n, undefined, 5_000);
+      const result = await service.repairTerminatedDataSet("0xaaa", 9n);
 
-      expect(terminateMock).toHaveBeenCalledWith({ dataSetId: 9n });
-      expect(waitForReceiptMock).toHaveBeenCalledWith({ hash: "0xhash" });
+      expect(terminateMock).toHaveBeenCalledWith(expect.objectContaining({ dataSetId: 9n }));
       expect(updateFn).toHaveBeenCalledWith(
         { dataSetId: 9n, cleanedUp: false },
         expect.objectContaining({ cleanedUp: true, cleanedUpAt: expect.any(Date) }),
@@ -1395,11 +1390,10 @@ describe("DealService", () => {
       expect(result.pdpEndEpoch).toBe(12345n);
     });
 
-    it("skips terminateDataSet when FWSS pdpEndEpoch is already non-zero (idempotent)", async () => {
+    it("skips terminateService when FWSS pdpEndEpoch is already non-zero (idempotent)", async () => {
       const terminateMock = vi.fn();
       const synapseMock = {
-        storage: { terminateDataSet: terminateMock },
-        client: { waitForTransactionReceipt: vi.fn() },
+        storage: { terminateService: terminateMock },
       };
       vi.spyOn(service as any, "createSynapseInstance").mockImplementation(() => synapseMock as unknown as Synapse);
 
@@ -1412,23 +1406,23 @@ describe("DealService", () => {
         value: { transaction: transactionMock },
       });
 
-      const result = await service.repairTerminatedDataSet("0xaaa", 9n, undefined, 5_000);
+      const result = await service.repairTerminatedDataSet("0xaaa", 9n);
 
       expect(terminateMock).not.toHaveBeenCalled();
       expect(updateFn).toHaveBeenCalled();
       expect(result.pdpEndEpoch).toBe(999n);
     });
 
-    it("treats already-terminated revert as a no-op and continues to cleanup", async () => {
-      const terminateMock = vi.fn().mockRejectedValue(new Error("Service already terminated"));
+    it("uses the endEpoch from terminateService when the SDK handles an already-terminated service", async () => {
+      // The SDK's provider-relayed terminateService resolves an already-terminated
+      // service internally (no provider tx, txHash undefined) and returns its endEpoch.
+      const terminateMock = vi.fn().mockResolvedValue({ dataSetId: 9n, endEpoch: 7n });
       const synapseMock = {
-        storage: { terminateDataSet: terminateMock },
-        client: { waitForTransactionReceipt: vi.fn() },
+        storage: { terminateService: terminateMock },
       };
       vi.spyOn(service as any, "createSynapseInstance").mockImplementation(() => synapseMock as unknown as Synapse);
 
       mockWarmStorageService.getDataSet.mockResolvedValueOnce({ pdpEndEpoch: 0n });
-      mockWarmStorageService.getDataSet.mockResolvedValueOnce({ pdpEndEpoch: 7n });
 
       const updateFn = vi.fn().mockResolvedValue({ affected: 0 });
       const transactionMock = vi.fn(async (cb: any) => cb({ getRepository: () => ({ update: updateFn }) }));
@@ -1437,7 +1431,7 @@ describe("DealService", () => {
         value: { transaction: transactionMock },
       });
 
-      const result = await service.repairTerminatedDataSet("0xaaa", 9n, undefined, 5_000);
+      const result = await service.repairTerminatedDataSet("0xaaa", 9n);
 
       expect(terminateMock).toHaveBeenCalled();
       expect(updateFn).toHaveBeenCalled();

--- a/apps/backend/src/deal/deal.service.ts
+++ b/apps/backend/src/deal/deal.service.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { setTimeout as setTimeoutAsync } from "node:timers/promises";
 import { METADATA_KEYS, SIZE_CONSTANTS, Synapse } from "@filoz/synapse-sdk";
 import { Injectable, Logger, type OnModuleDestroy, type OnModuleInit } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
@@ -737,11 +736,12 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
    * Repair a PDP-terminated dataset (FWSS may or may not have flipped pdpEndEpoch).
    *
    * Idempotent sequence:
-   *   1. Read FWSS pdpEndEpoch. If already non-zero, skip the on-chain call.
-   *   2. Otherwise call terminateDataSet, wait for the tx receipt, then poll
-   *      FWSS pdpEndEpoch until non-zero. A revert that matches a known
-   *      already-terminated message is treated as a no-op and falls through
-   *      to the poll, so a partially-completed prior run can complete.
+   *   1. Read FWSS pdpEndEpoch. If already non-zero, skip termination.
+   *   2. Otherwise call provider-relayed terminateService: the SDK signs the
+   *      EIP-712 authorization and the provider relays the on-chain tx. The call
+   *      resolves with the termination endEpoch once FWSS reports the service
+   *      terminated. The SDK treats an already-terminated or in-flight service as
+   *      a no-op, so a partially-completed prior run can complete.
    *   3. Mark every Deal row with this dataSetId as cleaned up in a single
    *      transaction (filtered on cleaned_up=false, so re-runs do not double-write).
    */
@@ -749,7 +749,6 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
     providerAddress: string,
     dataSetId: bigint,
     signal?: AbortSignal,
-    pollTimeoutMs = 60_000,
   ): Promise<{ dealsAffected: number; pdpEndEpoch: bigint }> {
     signal?.throwIfAborted();
     const synapse = this.sharedSynapse ?? (await this.createSynapseInstance());
@@ -762,46 +761,29 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
       pdpEndEpoch = existing.pdpEndEpoch;
       this.logger.log({
         event: "dataset_already_terminated",
-        message: "FWSS pdpEndEpoch already set; skipping terminateDataSet",
+        message: "FWSS pdpEndEpoch already set; skipping terminateService",
         providerAddress,
         dataSetId: dataSetId.toString(),
         pdpEndEpoch: pdpEndEpoch.toString(),
       });
     } else {
-      let txHash: `0x${string}` | undefined;
-      try {
-        txHash = await awaitWithAbort(synapse.storage.terminateDataSet({ dataSetId }), signal);
-      } catch (error) {
-        if (signal?.aborted) throw error;
-        const message = error instanceof Error ? error.message : String(error);
-        if (!/already.*terminat|service.*terminated|pdpEndEpoch.*set/i.test(message)) {
-          throw error;
-        }
-        this.logger.warn({
-          event: "dataset_terminate_already_handled",
-          message: "terminateDataSet reverted as already-terminated; continuing to poll",
-          providerAddress,
-          dataSetId: dataSetId.toString(),
-          revert: message,
-        });
-      }
       signal?.throwIfAborted();
-      if (txHash != null) {
-        try {
-          await awaitWithAbort(synapse.client.waitForTransactionReceipt({ hash: txHash }), signal);
-        } catch (error) {
-          if (signal?.aborted) throw error;
-          this.logger.warn({
-            event: "dataset_terminate_receipt_wait_failed",
-            message: "Receipt wait failed; falling back to FWSS state poll",
-            providerAddress,
-            dataSetId: dataSetId.toString(),
-            txHash,
-            error: toStructuredError(error),
-          });
-        }
-      }
-      pdpEndEpoch = await this.waitForPdpEndEpoch(dataSetId, pollTimeoutMs, signal);
+      const result = await awaitWithAbort(
+        synapse.storage.terminateService({
+          dataSetId,
+          onSubmitted: (txHash) => {
+            this.logger.log({
+              event: "dataset_terminate_submitted",
+              message: "Provider-relayed termination transaction submitted",
+              providerAddress,
+              dataSetId: dataSetId.toString(),
+              txHash,
+            });
+          },
+        }),
+        signal,
+      );
+      pdpEndEpoch = result.endEpoch;
     }
 
     const result = await this.dealRepository.manager.transaction(async (manager) => {
@@ -822,28 +804,6 @@ export class DealService implements OnModuleInit, OnModuleDestroy {
     });
 
     return { dealsAffected: result, pdpEndEpoch };
-  }
-
-  /**
-   * Poll FWSS getDataSet({dataSetId}).pdpEndEpoch until non-zero. Exponential
-   * backoff capped at 8s. Throws on timeout.
-   */
-  private async waitForPdpEndEpoch(dataSetId: bigint, timeoutMs: number, signal?: AbortSignal): Promise<bigint> {
-    const { warmStorageService } = this.walletSdkService.getWalletServices();
-    const start = Date.now();
-    let delay = 1_000;
-    while (Date.now() - start < timeoutMs) {
-      const info = await awaitWithAbort(warmStorageService.getDataSet({ dataSetId }), signal);
-      if (info != null && info.pdpEndEpoch !== 0n) {
-        return info.pdpEndEpoch;
-      }
-      const remaining = timeoutMs - (Date.now() - start);
-      if (remaining <= 0) break;
-      const wait = Math.min(delay, remaining);
-      await setTimeoutAsync(wait, undefined, { signal });
-      delay = Math.min(delay * 2, 8_000);
-    }
-    throw new Error(`Timeout waiting for FWSS pdpEndEpoch != 0 on dataSetId ${dataSetId.toString()}`);
   }
 
   /**

--- a/apps/backend/src/pull-check/pull-check.service.spec.ts
+++ b/apps/backend/src/pull-check/pull-check.service.spec.ts
@@ -16,9 +16,8 @@ import { PullPieceRepository } from "./pull-piece.repository.js";
 // strings rather than real CID objects, keeping the tests fast and isolated
 // from the SDK's internal hashing.
 vi.mock("@filoz/synapse-core/piece", () => ({
-  parse: vi.fn((s: string) => ({ __parsed: s, toString: () => s })),
-  calculate: vi.fn(() => ({ toString: () => "bafk-test-piece" })),
-  calculateFromIterable: vi.fn().mockResolvedValue("bafk-test-piece"),
+  from: vi.fn((s: string) => ({ __parsed: s, toString: () => s })),
+  calculate: vi.fn().mockResolvedValue("bafk-test-piece"),
 }));
 
 vi.mock("@filoz/synapse-core/sp", () => ({
@@ -26,7 +25,7 @@ vi.mock("@filoz/synapse-core/sp", () => ({
   waitForPullPieces: vi.fn(),
 }));
 
-import { calculateFromIterable } from "@filoz/synapse-core/piece";
+import { calculate } from "@filoz/synapse-core/piece";
 import { pullPieces, waitForPullPieces } from "@filoz/synapse-core/sp";
 
 function makeProvider(overrides: Partial<PDPProviderEx> = {}): PDPProviderEx {
@@ -208,7 +207,7 @@ describe("PullCheckService", () => {
         body: Readable.from([Buffer.from("payload")]),
       });
       if (cidResult !== "bafk-test-piece") {
-        vi.mocked(calculateFromIterable).mockResolvedValueOnce(cidResult as any);
+        vi.mocked(calculate).mockResolvedValueOnce(cidResult as any);
       }
     }
 
@@ -408,7 +407,7 @@ describe("PullCheckService", () => {
       // `validateByDirectPieceFetch` call `calculateFromIterable`, so chain
       // two one-shot mocks: the first satisfies prepare with the canonical
       // CID, the second makes the direct-fetch recompute disagree.
-      vi.mocked(calculateFromIterable)
+      vi.mocked(calculate)
         .mockResolvedValueOnce("bafk-test-piece" as any)
         .mockResolvedValueOnce("bafk-mismatch" as any);
 

--- a/apps/backend/src/pull-check/pull-check.service.ts
+++ b/apps/backend/src/pull-check/pull-check.service.ts
@@ -1,5 +1,5 @@
 import * as crypto from "node:crypto";
-import { calculateFromIterable, parse as parsePieceCid } from "@filoz/synapse-core/piece";
+import * as Piece from "@filoz/synapse-core/piece";
 import { pullPieces, waitForPullPieces } from "@filoz/synapse-core/sp";
 import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
@@ -90,7 +90,7 @@ export class PullCheckService {
       signal?.throwIfAborted();
       prepared = await this.preparePullPiece(spAddress);
       const pieceCidStr = prepared.registration.pieceCid;
-      const pieceCidParsed = parsePieceCid(pieceCidStr);
+      const pieceCidParsed = Piece.from(pieceCidStr);
 
       const synapseClient = this.requireSynapseClient();
 
@@ -258,7 +258,7 @@ export class PullCheckService {
       }
 
       try {
-        const calculatedPieceCid = await calculateFromIterable(response.body);
+        const calculatedPieceCid = await Piece.calculate(response.body);
         return calculatedPieceCid.toString() === pieceCid;
       } finally {
         // Guarantee the underlying socket is released if `calculateFromIterable`
@@ -300,7 +300,7 @@ export class PullCheckService {
       bytesNeeded: targetSize,
     });
 
-    const pieceCid = await calculateFromIterable(dataStream);
+    const pieceCid = await Piece.calculate(dataStream);
     const pieceCidStr = pieceCid.toString();
     const baseUrl = this.resolvePublicBaseUrl();
     const sourceUrl = `${baseUrl}/api/piece/${pieceCidStr}`;

--- a/apps/backend/src/pull-check/pull-piece.controller.ts
+++ b/apps/backend/src/pull-check/pull-piece.controller.ts
@@ -1,5 +1,5 @@
 import { PassThrough } from "node:stream";
-import { asPieceCID } from "@filoz/synapse-core/piece";
+import { tryFrom as pieceTryFrom } from "@filoz/synapse-core/piece";
 import { Controller, Get, Logger, NotFoundException, Param, Res, UseGuards } from "@nestjs/common";
 import { ApiResponse, ApiTags } from "@nestjs/swagger";
 import { ThrottlerGuard } from "@nestjs/throttler";
@@ -36,7 +36,7 @@ export class PieceSourceController {
       throw new NotFoundException("pieceCid is required");
     }
 
-    if (!asPieceCID(pieceCid)) {
+    if (!pieceTryFrom(pieceCid)) {
       throw new NotFoundException("pieceCid is invalid");
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,11 +45,11 @@ importers:
         specifier: ^1.11.0
         version: 1.18.2
       '@filoz/synapse-core':
-        specifier: 0.5.2
-        version: 0.5.2(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))
+        specifier: 0.7.0
+        version: 0.7.0(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))
       '@filoz/synapse-sdk':
-        specifier: 0.41.0
-        version: 0.41.0(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))
+        specifier: 1.0.1
+        version: 1.0.1(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))
       '@ipld/car':
         specifier: ^5.4.2
         version: 5.4.2
@@ -894,8 +894,18 @@ packages:
     peerDependencies:
       viem: 2.x
 
+  '@filoz/synapse-core@0.7.0':
+    resolution: {integrity: sha512-54G+yH1DrqXpCrtSZF5SYvNma3W2iA/LH6hLWmADy5tW1CkPlvtHZ5essqrJtlk3lfNRYMWk3+13ejzXxDAWWw==}
+    peerDependencies:
+      viem: 2.x
+
   '@filoz/synapse-sdk@0.41.0':
     resolution: {integrity: sha512-hbxV71Zjk1AExgghdP+LoYY1UqdnUMVB6Te1aJ5Af/e1lVDIOXIAHYm1WzSLCp6pU/a/+hLpGyl1CCu1IUPwYQ==}
+    peerDependencies:
+      viem: 2.x
+
+  '@filoz/synapse-sdk@1.0.1':
+    resolution: {integrity: sha512-zUAFPVPit9CNcOfjzv4oH+zqj0FkyVHJkXbeWpuJo4ZQxlCTieILpgEn7zR5LFnGKBpukzM0iIzW1mOEqGZ6jA==}
     peerDependencies:
       viem: 2.x
 
@@ -3015,6 +3025,10 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  bigint-mod-arith@3.3.1:
+    resolution: {integrity: sha512-pX/cYW3dCa87Jrzv6DAr8ivbbJRzEX5yGhdt8IutnX/PCIXfpx+mabWNK/M8qqh+zQ0J3thftUBHW0ByuUlG0w==}
+    engines: {node: '>=10.4.0'}
+
   binaryen@102.0.0-nightly.20211028:
     resolution: {integrity: sha512-GCJBVB5exbxzzvyt8MGDv/MeUjs6gkXDvf4xOIItRBptYl0Tz5sm1o/uG95YK0L0VeG5ajDu3hRtkBP2kzqC5w==}
     hasBin: true
@@ -4440,8 +4454,14 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  iso-base@4.4.0:
+    resolution: {integrity: sha512-W4BJbRDBi66wcBFJ23ZlGnFOZ874CIut4y9PlsScMSYu7ckCX+MWNAaEoE0efTSYDoVEn1qy0FDVSjE8q0ieHw==}
+
   iso-kv@3.1.1:
     resolution: {integrity: sha512-yKTLmUCc8gl0MXJs3ZaTaNDgfG/2ROasZERKPa5aYY7Ks/eb8BvGfLHrC+t1cHxiRkogvaXulDP77ovwLKgLPg==}
+
+  iso-kv@3.2.0:
+    resolution: {integrity: sha512-rMVXO7zDEecXOJEiDnbDqjZ7gSe7VqDn2FTkUFWeqkcYMmgMdmB7pDgUaZxiEyiL1+gO7RnbqEI2Ce3xIW4UBQ==}
 
   iso-url@1.2.1:
     resolution: {integrity: sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==}
@@ -4449,6 +4469,9 @@ packages:
 
   iso-web@2.2.1:
     resolution: {integrity: sha512-4pkaxMAK089Gt+ua046Y0vGu7V7V7+P/2fEzlxYK0ssMvQFufaqkETHhoid+422L/kjU7aw9j1BxorpG6jmtXw==}
+
+  iso-web@3.1.2:
+    resolution: {integrity: sha512-OpWz+KNH4vYNVvpc6T1z/zkZtT6iTQXYjc0sIbkPDwYEM5Qurg0LYESrEHloxb6xj5T/2rrnsTtaYlUSIzgicg==}
 
   isomorphic-ws@4.0.1:
     resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
@@ -4734,6 +4757,10 @@ packages:
   kysely@0.28.17:
     resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
     engines: {node: '>=20.0.0'}
+
+  kysely@0.29.2:
+    resolution: {integrity: sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==}
+    engines: {node: '>=22.0.0'}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -5378,6 +5405,14 @@ packages:
 
   ox@0.14.20:
     resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  ox@0.14.29:
+    resolution: {integrity: sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -7625,10 +7660,33 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  '@filoz/synapse-core@0.7.0(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))':
+    dependencies:
+      dnum: 2.17.0
+      iso-web: 3.1.2
+      multiformats: 14.0.0
+      ox: 0.14.29(typescript@5.9.3)(zod@4.4.3)
+      p-locate: 7.0.0
+      p-queue: 9.2.0
+      p-some: 7.0.0
+      sync-multihash-sha2: 1.0.0
+      viem: 2.48.11(typescript@5.9.3)(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - typescript
+
   '@filoz/synapse-sdk@0.41.0(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))':
     dependencies:
       '@filoz/synapse-core': 0.5.2(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))
       multiformats: 13.4.2
+      viem: 2.48.11(typescript@5.9.3)(zod@4.4.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@filoz/synapse-sdk@1.0.1(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))':
+    dependencies:
+      '@filoz/synapse-core': 0.7.0(typescript@5.9.3)(viem@2.48.11(typescript@5.9.3)(zod@4.4.3))
+      multiformats: 14.0.0
       viem: 2.48.11(typescript@5.9.3)(zod@4.4.3)
     transitivePeerDependencies:
       - typescript
@@ -10654,6 +10712,8 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  bigint-mod-arith@3.3.1: {}
+
   binaryen@102.0.0-nightly.20211028: {}
 
   binaryen@116.0.0-nightly.20240114: {}
@@ -12268,11 +12328,22 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  iso-base@4.4.0:
+    dependencies:
+      bigint-mod-arith: 3.3.1
+
   iso-kv@3.1.1:
     dependencies:
       conf: 15.1.0
       idb-keyval: 6.2.2
       kysely: 0.28.17
+
+  iso-kv@3.2.0:
+    dependencies:
+      conf: 15.1.0
+      idb-keyval: 6.2.2
+      iso-base: 4.4.0
+      kysely: 0.29.2
 
   iso-url@1.2.1: {}
 
@@ -12281,6 +12352,14 @@ snapshots:
       delay: 7.0.0
       is-network-error: 1.3.2
       iso-kv: 3.1.1
+      p-retry: 8.0.0
+
+  iso-web@3.1.2:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      delay: 7.0.0
+      is-network-error: 1.3.2
+      iso-kv: 3.2.0
       p-retry: 8.0.0
 
   isomorphic-ws@4.0.1(ws@7.5.10):
@@ -12705,6 +12784,8 @@ snapshots:
       - undici
 
   kysely@0.28.17: {}
+
+  kysely@0.29.2: {}
 
   leven@3.1.0: {}
 
@@ -13449,6 +13530,21 @@ snapshots:
       - zod
 
   ox@0.14.20(typescript@5.9.3)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.29(typescript@5.9.3)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0


### PR DESCRIPTION
Closes #546 

**Note:** Need `filecoin-pin` utilizing `synapse-sdk^1.0.1` and `synapse-core^0.7.0`.