### PR TITLE
fix(rpc): raise viem RPC timeout above eRPC failover budget

### DIFF
--- a/apps/backend/src/common/synapse-factory.ts
+++ b/apps/backend/src/common/synapse-factory.ts
@@ -39,7 +39,14 @@ export interface SynapseInstanceResult {
 export async function createSynapseFromConfig(config: IBlockchainConfig): Promise<SynapseInstanceResult> {
   const chain = config.network === "mainnet" ? mainnet : calibration;
   const rpcUrl = config.rpcUrl;
-  const transport = rpcUrl ? http(rpcUrl) : http();
+  // Keep this timeout above eRPC's network failsafe budget so eRPC can fail
+  // over to a fallback upstream before we abort. viem's default is 10s, which
+  // is below eRPC's budget and turns slow-upstream latency into hard failures.
+  // See #603.
+  const transportOpts = { timeout: config.rpcRequestTimeoutMs };
+  // Always carries the configured timeout. With no rpcUrl, http(undefined)
+  // falls back to the chain's default RPC, so the timeout applies on every path.
+  const transport = rpcUrl ? http(rpcUrl, transportOpts) : http(undefined, transportOpts);
   const sessionKeyPK = config.sessionKeyPrivateKey;
 
   if (sessionKeyPK) {
@@ -100,7 +107,7 @@ export async function createSynapseFromConfig(config: IBlockchainConfig): Promis
       account: privateKeyToAccount(config.walletPrivateKey),
       chain,
       source: "dealbot",
-      ...(rpcUrl ? { transport } : {}),
+      transport,
     }),
     isSessionKeyMode: false,
   };

--- a/apps/backend/src/config/app.config.ts
+++ b/apps/backend/src/config/app.config.ts
@@ -52,6 +52,11 @@ export const configValidationSchema = Joi.object({
     .uri({ scheme: ["http", "https"] })
     .optional()
     .allow(""),
+  // Per-request RPC timeout for the viem transport. Must stay ABOVE eRPC's
+  // network failsafe timeout so eRPC can fail over to a fallback upstream
+  // before dealbot gives up. viem's own default is 10s, which is below eRPC's
+  // budget and causes premature client aborts. See #603.
+  RPC_REQUEST_TIMEOUT_MS: Joi.number().integer().min(1000).default(30000),
   SESSION_KEY_PRIVATE_KEY: Joi.string().optional().empty(""),
   CHECK_DATASET_CREATION_FEES: Joi.boolean().default(true),
   USE_ONLY_APPROVED_PROVIDERS: Joi.boolean().default(true),
@@ -198,6 +203,7 @@ export interface IDatabaseConfig {
 export interface IBlockchainConfig {
   network: Network;
   rpcUrl?: string;
+  rpcRequestTimeoutMs: number;
   sessionKeyPrivateKey?: `0x${string}`;
   walletAddress: string;
   walletPrivateKey: `0x${string}`;
@@ -475,6 +481,7 @@ export function loadConfig(): IConfig {
     blockchain: {
       network: (process.env.NETWORK || "calibration") as Network,
       rpcUrl: process.env.RPC_URL || undefined,
+      rpcRequestTimeoutMs: Number.parseInt(process.env.RPC_REQUEST_TIMEOUT_MS || "30000", 10),
       sessionKeyPrivateKey: (process.env.SESSION_KEY_PRIVATE_KEY || undefined) as `0x${string}` | undefined,
       walletAddress: process.env.WALLET_ADDRESS || "0x0000000000000000000000000000000000000000",
       walletPrivateKey: (process.env.WALLET_PRIVATE_KEY || undefined) as `0x${string}`,

--- a/apps/backend/src/wallet-sdk/wallet-sdk.service.spec.ts
+++ b/apps/backend/src/wallet-sdk/wallet-sdk.service.spec.ts
@@ -13,6 +13,7 @@ type LoggerLike = {
 
 const baseConfig: IBlockchainConfig = {
   network: "calibration",
+  rpcRequestTimeoutMs: 30000,
   walletAddress: "0x0000000000000000000000000000000000000000",
   walletPrivateKey: "0xtest",
   checkDatasetCreationFees: false,


### PR DESCRIPTION
## What changed

viem's `http()` transport defaults to a 10s per-request timeout. eRPC's network failsafe budget is 30s. When the upstream (chain.love) is slow but not erroring, dealbot aborts at 10s before eRPC can fail over to Ankr, so latency becomes hard deal failures (the `"The request took too long to respond"` errors).

This adds `RPC_REQUEST_TIMEOUT_MS` (default `30000`) and applies it to the viem transport in `synapse-factory.ts`, so the client timeout sits above eRPC's budget and lets eRPC's failover machinery finish first.

## How to verify

- `RPC_REQUEST_TIMEOUT_MS` unset defaults to 30000; the viem transport is built with `{ timeout }` in all three paths (default, session-key, `Synapse.create`).
- `pnpm typecheck` passes.

## Notes

Pairs with FilOzone/infra PR that drops eRPC's network `timeout` to 20s and adds a `hedge` policy. Ordering only fully holds once both land: dealbot (30s) > eRPC network timeout (20s). Tracking: #603.
